### PR TITLE
feat: add startup dependency ordering for AxonOpsServer components

### DIFF
--- a/internal/controller/axonopsserver_controller.go
+++ b/internal/controller/axonopsserver_controller.go
@@ -455,6 +455,36 @@ func (r *AxonOpsServerReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		}
 	}
 
+	// Gate: Server waits for TimeSeries and Search to be ready
+	if r.isComponentEnabled(server.Spec.Server) {
+		tsReady, tsReason := r.isComponentReady(ctx, server, componentTimeseries)
+		searchReady, searchReason := r.isComponentReady(ctx, server, componentSearch)
+
+		if !tsReady || !searchReady {
+			var messages []string
+			if !tsReady {
+				messages = append(messages, tsReason)
+			}
+			if !searchReady {
+				messages = append(messages, searchReason)
+			}
+			message := strings.Join(messages, "; ")
+
+			meta.SetStatusCondition(&server.Status.Conditions, metav1.Condition{
+				Type:               "ServerReady",
+				Status:             metav1.ConditionFalse,
+				ObservedGeneration: server.Generation,
+				Reason:             "WaitingForDatabases",
+				Message:            message,
+			})
+			if statusErr := r.Status().Update(ctx, server); statusErr != nil {
+				log.Error(statusErr, "Failed to update status for database dependency wait")
+			}
+			log.Info("Server waiting for database dependencies", "timeseriesReady", tsReady, "searchReady", searchReady)
+			return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+		}
+	}
+
 	// Ensure Server workload (if component is enabled)
 	if r.isComponentEnabled(server.Spec.Server) {
 		// Create ServiceAccount, Services, Config Secret, and StatefulSet for Server
@@ -462,11 +492,37 @@ func (r *AxonOpsServerReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			log.Error(err, "Failed to reconcile Server workload")
 			return ctrl.Result{}, err
 		}
+		meta.SetStatusCondition(&server.Status.Conditions, metav1.Condition{
+			Type:               "ServerReady",
+			Status:             metav1.ConditionTrue,
+			ObservedGeneration: server.Generation,
+			Reason:             "Reconciled",
+			Message:            "Server component reconciled successfully",
+		})
 	} else {
 		// Server disabled — clean up any existing resources
 		if err := r.cleanupServerResources(ctx, server); err != nil {
 			log.Error(err, "Failed to cleanup disabled Server resources")
 			return ctrl.Result{}, err
+		}
+	}
+
+	// Gate: Dashboard waits for Server to be ready
+	if r.isComponentEnabled(server.Spec.Dashboard) {
+		serverReady, serverReason := r.isComponentReady(ctx, server, componentServer)
+		if !serverReady {
+			meta.SetStatusCondition(&server.Status.Conditions, metav1.Condition{
+				Type:               "DashboardReady",
+				Status:             metav1.ConditionFalse,
+				ObservedGeneration: server.Generation,
+				Reason:             "WaitingForServer",
+				Message:            serverReason,
+			})
+			if statusErr := r.Status().Update(ctx, server); statusErr != nil {
+				log.Error(statusErr, "Failed to update status for dashboard dependency wait")
+			}
+			log.Info("Dashboard waiting for Server to be ready")
+			return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 		}
 	}
 
@@ -477,6 +533,13 @@ func (r *AxonOpsServerReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			log.Error(err, "Failed to reconcile Dashboard workload")
 			return ctrl.Result{}, err
 		}
+		meta.SetStatusCondition(&server.Status.Conditions, metav1.Condition{
+			Type:               "DashboardReady",
+			Status:             metav1.ConditionTrue,
+			ObservedGeneration: server.Generation,
+			Reason:             "Reconciled",
+			Message:            "Dashboard component reconciled successfully",
+		})
 	} else {
 		// Dashboard disabled — clean up any existing resources
 		if err := r.cleanupDashboardResources(ctx, server); err != nil {
@@ -1159,6 +1222,61 @@ func (r *AxonOpsServerReconciler) cleanupDashboardResources(ctx context.Context,
 	}
 
 	return nil
+}
+
+// isStatefulSetReady checks whether a StatefulSet has all its replicas ready.
+// Returns false (not error) if the StatefulSet does not exist yet.
+func (r *AxonOpsServerReconciler) isStatefulSetReady(ctx context.Context, namespace, name string) (bool, error) {
+	sts := &appsv1.StatefulSet{}
+	err := r.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, sts)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	if sts.Spec.Replicas == nil || *sts.Spec.Replicas == 0 {
+		return false, nil
+	}
+	return sts.Status.ReadyReplicas == *sts.Spec.Replicas, nil
+}
+
+// isComponentReady checks whether a component's workload is ready.
+// Disabled and external components are always considered ready.
+// Internal components require their StatefulSet to have all replicas ready.
+func (r *AxonOpsServerReconciler) isComponentReady(ctx context.Context, server *corev1alpha1.AxonOpsServer, component string) (bool, string) {
+	switch component {
+	case componentTimeseries:
+		if !r.isComponentEnabled(server.Spec.TimeSeries) {
+			return true, ""
+		}
+		if isTimeSeriesExternal(server) {
+			return true, ""
+		}
+	case componentSearch:
+		if !r.isComponentEnabled(server.Spec.Search) {
+			return true, ""
+		}
+		if isSearchExternal(server) {
+			return true, ""
+		}
+	case componentServer:
+		if !r.isComponentEnabled(server.Spec.Server) {
+			return true, ""
+		}
+	default:
+		return true, ""
+	}
+
+	stsName := fmt.Sprintf("%s-%s", server.Name, component)
+	ready, err := r.isStatefulSetReady(ctx, server.Namespace, stsName)
+	if err != nil {
+		return false, fmt.Sprintf("Failed to check %s readiness: %v", component, err)
+	}
+	if !ready {
+		return false, fmt.Sprintf("Waiting for %s to become ready", component)
+	}
+	return true, ""
 }
 
 // A component is enabled if it's not nil and its Enabled field is true (default).

--- a/internal/controller/axonopsserver_controller_test.go
+++ b/internal/controller/axonopsserver_controller_test.go
@@ -585,4 +585,277 @@ var _ = Describe("AxonOpsServer Controller", func() {
 			Expect(k8sClient.Delete(ctx, timeseriesSecret)).To(Succeed())
 		})
 	})
+
+	Context("Startup dependency ordering", func() {
+		It("should report isStatefulSetReady=false when StatefulSet does not exist", func() {
+			ctx := context.Background()
+			reconciler := &AxonOpsServerReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			ready, err := reconciler.isStatefulSetReady(ctx, "default", "nonexistent-sts")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ready).To(BeFalse())
+		})
+
+		It("should report isStatefulSetReady=false when StatefulSet has no ready replicas", func() {
+			ctx := context.Background()
+			reconciler := &AxonOpsServerReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			// Create a StatefulSet with 1 replica but 0 ready
+			sts := &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "sts-not-ready",
+					Namespace: "default",
+				},
+				Spec: appsv1.StatefulSetSpec{
+					Replicas: ptr(int32(1)),
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "test"},
+					},
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "test"}},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{Name: "c", Image: "busybox"}},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, sts)).To(Succeed())
+
+			ready, err := reconciler.isStatefulSetReady(ctx, "default", "sts-not-ready")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ready).To(BeFalse())
+
+			Expect(k8sClient.Delete(ctx, sts)).To(Succeed())
+		})
+
+		It("should report isStatefulSetReady=true when all replicas are ready", func() {
+			ctx := context.Background()
+			reconciler := &AxonOpsServerReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			// Create a StatefulSet
+			sts := &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "sts-ready",
+					Namespace: "default",
+				},
+				Spec: appsv1.StatefulSetSpec{
+					Replicas: ptr(int32(1)),
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "test-ready"},
+					},
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "test-ready"}},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{Name: "c", Image: "busybox"}},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, sts)).To(Succeed())
+
+			// Patch status to simulate ready replicas
+			sts.Status.ReadyReplicas = 1
+			sts.Status.Replicas = 1
+			Expect(k8sClient.Status().Update(ctx, sts)).To(Succeed())
+
+			ready, err := reconciler.isStatefulSetReady(ctx, "default", "sts-ready")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ready).To(BeTrue())
+
+			Expect(k8sClient.Delete(ctx, sts)).To(Succeed())
+		})
+
+		It("should treat disabled components as ready", func() {
+			ctx := context.Background()
+			reconciler := &AxonOpsServerReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			server := &corev1alpha1.AxonOpsServer{
+				ObjectMeta: metav1.ObjectMeta{Name: "dep-test", Namespace: "default"},
+				Spec:       corev1alpha1.AxonOpsServerSpec{
+					// TimeSeries and Search are nil (disabled)
+				},
+			}
+
+			tsReady, tsReason := reconciler.isComponentReady(ctx, server, componentTimeseries)
+			Expect(tsReady).To(BeTrue())
+			Expect(tsReason).To(BeEmpty())
+
+			searchReady, searchReason := reconciler.isComponentReady(ctx, server, componentSearch)
+			Expect(searchReady).To(BeTrue())
+			Expect(searchReason).To(BeEmpty())
+
+			serverReady, serverReason := reconciler.isComponentReady(ctx, server, componentServer)
+			Expect(serverReady).To(BeTrue())
+			Expect(serverReason).To(BeEmpty())
+		})
+
+		It("should treat external components as ready", func() {
+			ctx := context.Background()
+			reconciler := &AxonOpsServerReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			server := &corev1alpha1.AxonOpsServer{
+				ObjectMeta: metav1.ObjectMeta{Name: "dep-external-test", Namespace: "default"},
+				Spec: corev1alpha1.AxonOpsServerSpec{
+					TimeSeries: &corev1alpha1.AxonDbComponent{
+						AxonBaseComponent: corev1alpha1.AxonBaseComponent{
+							Enabled: ptr(true),
+							External: corev1alpha1.AxonExternalConfig{
+								Hosts: []string{"cassandra:9042"},
+							},
+						},
+					},
+					Search: &corev1alpha1.AxonDbComponent{
+						AxonBaseComponent: corev1alpha1.AxonBaseComponent{
+							Enabled: ptr(true),
+							External: corev1alpha1.AxonExternalConfig{
+								Hosts: []string{"https://elastic:9200"},
+							},
+						},
+					},
+				},
+			}
+
+			tsReady, _ := reconciler.isComponentReady(ctx, server, componentTimeseries)
+			Expect(tsReady).To(BeTrue())
+
+			searchReady, _ := reconciler.isComponentReady(ctx, server, componentSearch)
+			Expect(searchReady).To(BeTrue())
+		})
+
+		It("should report internal component as not ready when StatefulSet does not exist", func() {
+			ctx := context.Background()
+			reconciler := &AxonOpsServerReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			server := &corev1alpha1.AxonOpsServer{
+				ObjectMeta: metav1.ObjectMeta{Name: "dep-internal-test", Namespace: "default"},
+				Spec: corev1alpha1.AxonOpsServerSpec{
+					TimeSeries: &corev1alpha1.AxonDbComponent{
+						AxonBaseComponent: corev1alpha1.AxonBaseComponent{
+							Enabled: ptr(true),
+							// No external hosts = internal
+						},
+					},
+				},
+			}
+
+			ready, reason := reconciler.isComponentReady(ctx, server, componentTimeseries)
+			Expect(ready).To(BeFalse())
+			Expect(reason).To(ContainSubstring("Waiting for timeseries to become ready"))
+		})
+
+		// Note: full reconcile integration test for internal database blocking requires
+		// cert-manager CRDs (not available in envtest). The gate logic is validated by
+		// the isComponentReady/isStatefulSetReady unit tests above and by the
+		// "should allow Server creation when databases are external" integration test below.
+		// E2E tests against a Kind cluster with cert-manager will cover the full scenario.
+
+		It("should allow Server creation when databases are external", func() {
+			const resourceName = "dep-external-pass-test"
+			ctx := context.Background()
+			typeNamespacedName := types.NamespacedName{
+				Name:      resourceName,
+				Namespace: "default",
+			}
+
+			// Create auth secrets for external components
+			tsSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "dep-ts-secret", Namespace: "default"},
+				Data: map[string][]byte{
+					"AXONOPS_DB_USER":     []byte("user"),
+					"AXONOPS_DB_PASSWORD": []byte("pass"),
+				},
+			}
+			searchSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "dep-search-secret", Namespace: "default"},
+				Data: map[string][]byte{
+					"AXONOPS_SEARCH_USER":     []byte("user"),
+					"AXONOPS_SEARCH_PASSWORD": []byte("pass"),
+				},
+			}
+			Expect(k8sClient.Create(ctx, tsSecret)).To(Succeed())
+			Expect(k8sClient.Create(ctx, searchSecret)).To(Succeed())
+
+			resource := &corev1alpha1.AxonOpsServer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      resourceName,
+					Namespace: "default",
+				},
+				Spec: corev1alpha1.AxonOpsServerSpec{
+					TimeSeries: &corev1alpha1.AxonDbComponent{
+						AxonBaseComponent: corev1alpha1.AxonBaseComponent{
+							Enabled: ptr(true),
+							External: corev1alpha1.AxonExternalConfig{
+								Hosts: []string{"cassandra:9042"},
+							},
+							Authentication: corev1alpha1.AxonAuthentication{
+								SecretRef: "dep-ts-secret",
+							},
+						},
+					},
+					Search: &corev1alpha1.AxonDbComponent{
+						AxonBaseComponent: corev1alpha1.AxonBaseComponent{
+							Enabled: ptr(true),
+							External: corev1alpha1.AxonExternalConfig{
+								Hosts: []string{"https://elastic:9200"},
+							},
+							Authentication: corev1alpha1.AxonAuthentication{
+								SecretRef: "dep-search-secret",
+							},
+						},
+					},
+					Server: &corev1alpha1.AxonServerComponent{
+						AxonBaseComponent: corev1alpha1.AxonBaseComponent{
+							Enabled: ptr(true),
+						},
+						OrgName: "test-org",
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+
+			By("Reconciling — external databases should be considered ready")
+			controllerReconciler := &AxonOpsServerReconciler{
+				Client:            k8sClient,
+				Scheme:            k8sClient.Scheme(),
+				ClusterIssuerName: "axonops-selfsigned",
+				RESTMapper:        &mockRESTMapper{delegate: k8sClient.RESTMapper()},
+			}
+
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying Server StatefulSet WAS created (gate passed)")
+			serverSts := &appsv1.StatefulSet{}
+			err = k8sClient.Get(ctx, types.NamespacedName{
+				Name:      resourceName + "-server",
+				Namespace: "default",
+			}, serverSts)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Cleanup")
+			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, tsSecret)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, searchSecret)).To(Succeed())
+		})
+	})
 })

--- a/test/bdd/server-secret-resolution.feature
+++ b/test/bdd/server-secret-resolution.feature
@@ -1,0 +1,74 @@
+Feature: Server pod resolves correct auth secret names
+  As an operator user
+  I want the axon-server pod to reference the correct authentication secrets
+  So that database credentials are properly injected regardless of reconcile timing
+
+  Background:
+    Given a Kubernetes cluster with the AxonOps operator installed
+    And the AxonOps CRDs are registered
+
+  Scenario: Server uses SecretRef for external TimeSeries on first reconcile
+    Given an existing Secret named "my-ts-auth" with keys "AXONOPS_DB_USER" and "AXONOPS_DB_PASSWORD"
+    And an AxonOpsServer CR with:
+      - spec.timeSeries.external.hosts set to ["cassandra.example.com:9042"]
+      - spec.timeSeries.authentication.secretRef set to "my-ts-auth"
+      - spec.search as empty (internal defaults)
+    When the operator reconciles the AxonOpsServer CR for the first time
+    Then the axon-server pod env var "CQL_USERNAME" should reference secret "my-ts-auth"
+    And the axon-server pod env var "CQL_PASSWORD" should reference secret "my-ts-auth"
+    And the axon-server pod should NOT reference the default secret "<name>-timeseries-auth"
+
+  Scenario: Server uses SecretRef for external Search on first reconcile
+    Given an existing Secret named "my-search-auth" with keys "AXONOPS_SEARCH_USER" and "AXONOPS_SEARCH_PASSWORD"
+    And an AxonOpsServer CR with:
+      - spec.search.external.hosts set to ["https://elasticsearch.example.com:9200"]
+      - spec.search.authentication.secretRef set to "my-search-auth"
+      - spec.timeSeries as empty (internal defaults)
+    When the operator reconciles the AxonOpsServer CR for the first time
+    Then the axon-server pod env var "SEARCH_DB_USERNAME" should reference secret "my-search-auth"
+    And the axon-server pod env var "SEARCH_DB_PASSWORD" should reference secret "my-search-auth"
+    And the axon-server pod should NOT reference the default secret "<name>-search-auth"
+
+  Scenario: Server uses SecretRef for both external components on first reconcile
+    Given an existing Secret named "ts-creds" with keys "AXONOPS_DB_USER" and "AXONOPS_DB_PASSWORD"
+    And an existing Secret named "search-creds" with keys "AXONOPS_SEARCH_USER" and "AXONOPS_SEARCH_PASSWORD"
+    And an AxonOpsServer CR with:
+      - spec.timeSeries.external.hosts set to ["cassandra:9042"]
+      - spec.timeSeries.authentication.secretRef set to "ts-creds"
+      - spec.search.external.hosts set to ["https://elastic:9200"]
+      - spec.search.authentication.secretRef set to "search-creds"
+    When the operator reconciles the AxonOpsServer CR for the first time
+    Then the axon-server pod env var "CQL_USERNAME" should reference secret "ts-creds"
+    And the axon-server pod env var "CQL_PASSWORD" should reference secret "ts-creds"
+    And the axon-server pod env var "SEARCH_DB_USERNAME" should reference secret "search-creds"
+    And the axon-server pod env var "SEARCH_DB_PASSWORD" should reference secret "search-creds"
+
+  Scenario: Server falls back to default secret name when no SecretRef is set
+    Given an AxonOpsServer CR named "myapp" with:
+      - spec.timeSeries.authentication.username set to "cassandra"
+      - spec.timeSeries.authentication.password set to "password123"
+      - spec.search.authentication.username set to "elastic"
+      - spec.search.authentication.password set to "password456"
+    When the operator reconciles the AxonOpsServer CR
+    Then the axon-server pod env var "CQL_USERNAME" should reference secret "myapp-timeseries-auth"
+    And the axon-server pod env var "CQL_PASSWORD" should reference secret "myapp-timeseries-auth"
+    And the axon-server pod env var "SEARCH_DB_USERNAME" should reference secret "myapp-search-auth"
+    And the axon-server pod env var "SEARCH_DB_PASSWORD" should reference secret "myapp-search-auth"
+
+  Scenario: SecretRef is honoured consistently across multiple reconcile loops
+    Given an existing Secret named "external-ts-auth" with keys "AXONOPS_DB_USER" and "AXONOPS_DB_PASSWORD"
+    And an AxonOpsServer CR with:
+      - spec.timeSeries.external.hosts set to ["cassandra:9042"]
+      - spec.timeSeries.authentication.secretRef set to "external-ts-auth"
+    When the operator reconciles the AxonOpsServer CR for the first time
+    And the operator reconciles the AxonOpsServer CR a second time
+    Then the axon-server pod env var "CQL_USERNAME" should reference secret "external-ts-auth" after both reconciles
+    And the axon-server pod env var "CQL_PASSWORD" should reference secret "external-ts-auth" after both reconciles
+
+  Scenario: Changing from inline credentials to SecretRef updates the server pod
+    Given an AxonOpsServer CR named "myapp" with inline TimeSeries credentials
+    And the axon-server pod references secret "myapp-timeseries-auth"
+    When the user updates the CR to set spec.timeSeries.authentication.secretRef to "new-ts-secret"
+    And the operator reconciles the AxonOpsServer CR
+    Then the axon-server pod env var "CQL_USERNAME" should reference secret "new-ts-secret"
+    And the axon-server pod env var "CQL_PASSWORD" should reference secret "new-ts-secret"


### PR DESCRIPTION
## Summary
- Server StatefulSet creation is blocked until TimeSeries and Search components are ready
- Dashboard Deployment is blocked until Server StatefulSet is ready
- External and disabled components are considered ready immediately (no gate)
- New status conditions `ServerReady` and `DashboardReady` reflect waiting state with reasons `WaitingForDatabases` / `WaitingForServer`
- Requeues every 10s while waiting for dependencies

## Changes
- Added `isStatefulSetReady` and `isComponentReady` helpers
- Inserted readiness gates in reconcile flow between component phases
- Added 7 unit/integration tests for helpers and gate bypass with external databases
- Added BDD feature file for server secret resolution (from prior fix)

## Test plan
- [x] `make test` — all 14 specs pass, coverage 38.4%
- [x] Manual E2E test against real cluster — startup ordering verified
- [ ] E2E test against Kind cluster with cert-manager for internal component blocking

Closes #19