### PR TITLE
fix: config changes to Secrets and ConfigMaps trigger pod rolling updates

### DIFF
--- a/internal/controller/axonopsserver_controller.go
+++ b/internal/controller/axonopsserver_controller.go
@@ -1602,6 +1602,13 @@ func (r *AxonOpsServerReconciler) ensureTimeseriesStatefulSet(ctx context.Contex
 		orgName = strings.ToLower(server.Spec.Server.OrgName)
 	}
 
+	// Fetch the auth secret to compute a checksum for rolling updates
+	authSecret := &corev1.Secret{}
+	if err := r.Get(ctx, types.NamespacedName{Name: timeseriesAuthSecretName, Namespace: server.Namespace}, authSecret); err != nil {
+		return fmt.Errorf("failed to get timeseries auth secret %s: %w", timeseriesAuthSecretName, err)
+	}
+	podAnnotations := mergeAnnotationsWithChecksum(ts.Annotations, "checksum/auth", configDataHash(authSecret.Data))
+
 	op, err := controllerutil.CreateOrUpdate(ctx, r.Client, sts, func() error {
 		if err := controllerutil.SetControllerReference(server, sts, r.Scheme); err != nil {
 			return err
@@ -1624,7 +1631,7 @@ func (r *AxonOpsServerReconciler) ensureTimeseriesStatefulSet(ctx context.Contex
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels:      labels,
-					Annotations: ts.Annotations,
+					Annotations: podAnnotations,
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName: name,
@@ -1905,6 +1912,13 @@ func (r *AxonOpsServerReconciler) ensureSearchStatefulSet(ctx context.Context, s
 	fqdn := fmt.Sprintf("%s.%s.svc.cluster.local", name, server.Namespace)
 	clusterName := fmt.Sprintf("%s-cluster", name)
 
+	// Fetch the auth secret to compute a checksum for rolling updates
+	searchAuthSecret := &corev1.Secret{}
+	if err := r.Get(ctx, types.NamespacedName{Name: searchAuthSecretName, Namespace: server.Namespace}, searchAuthSecret); err != nil {
+		return fmt.Errorf("failed to get search auth secret %s: %w", searchAuthSecretName, err)
+	}
+	podAnnotations := mergeAnnotationsWithChecksum(search.Annotations, "checksum/auth", configDataHash(searchAuthSecret.Data))
+
 	sts := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -1938,7 +1952,7 @@ func (r *AxonOpsServerReconciler) ensureSearchStatefulSet(ctx context.Context, s
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels:      labels,
-					Annotations: search.Annotations,
+					Annotations: podAnnotations,
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName:            name,
@@ -2722,6 +2736,13 @@ func (r *AxonOpsServerReconciler) ensureServerStatefulSet(ctx context.Context, s
 		}
 	}
 
+	// Fetch the config secret to compute a checksum for rolling updates
+	configSecret := &corev1.Secret{}
+	if err := r.Get(ctx, types.NamespacedName{Name: configSecretName, Namespace: server.Namespace}, configSecret); err != nil {
+		return fmt.Errorf("failed to get server config secret %s: %w", configSecretName, err)
+	}
+	podAnnotations := mergeAnnotationsWithChecksum(srv.Annotations, "checksum/config", configDataHash(configSecret.Data))
+
 	sts := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -2755,7 +2776,7 @@ func (r *AxonOpsServerReconciler) ensureServerStatefulSet(ctx context.Context, s
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels:      labels,
-					Annotations: srv.Annotations,
+					Annotations: podAnnotations,
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName: name,
@@ -3136,6 +3157,13 @@ func (r *AxonOpsServerReconciler) ensureDashboardDeployment(ctx context.Context,
 		replicas = *dash.Replicas
 	}
 
+	// Fetch the ConfigMap to compute a checksum for rolling updates
+	dashConfigMap := &corev1.ConfigMap{}
+	if err := r.Get(ctx, types.NamespacedName{Name: configMapName, Namespace: server.Namespace}, dashConfigMap); err != nil {
+		return fmt.Errorf("failed to get dashboard ConfigMap %s: %w", configMapName, err)
+	}
+	podAnnotations := mergeAnnotationsWithChecksum(dash.Annotations, "checksum/config", configStringDataHash(dashConfigMap.Data))
+
 	deploy := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -3160,7 +3188,7 @@ func (r *AxonOpsServerReconciler) ensureDashboardDeployment(ctx context.Context,
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels:      labels,
-					Annotations: dash.Annotations,
+					Annotations: podAnnotations,
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName: name,

--- a/internal/controller/config_hash.go
+++ b/internal/controller/config_hash.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"maps"
+	"slices"
+	"sort"
+)
+
+// configDataHash computes a deterministic SHA-256 hash of config data.
+// Keys are sorted lexicographically before hashing to ensure identical
+// output regardless of Go map iteration order. Returns an empty string
+// for nil or empty input.
+func configDataHash(data map[string][]byte) string {
+	if len(data) == 0 {
+		return ""
+	}
+
+	keys := make([]string, 0, len(data))
+	for k := range data {
+		keys = append(keys, k)
+	}
+	slices.Sort(keys)
+
+	h := sha256.New()
+	for _, k := range keys {
+		_, _ = fmt.Fprintf(h, "%s=%s\n", k, data[k])
+	}
+
+	return hex.EncodeToString(h.Sum(nil))[:32]
+}
+
+// configStringDataHash computes a deterministic SHA-256 hash of string config data.
+// Used for ConfigMap .Data fields which are map[string]string.
+func configStringDataHash(data map[string]string) string {
+	if len(data) == 0 {
+		return ""
+	}
+
+	keys := make([]string, 0, len(data))
+	for k := range data {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	h := sha256.New()
+	for _, k := range keys {
+		_, _ = fmt.Fprintf(h, "%s=%s\n", k, data[k])
+	}
+
+	return hex.EncodeToString(h.Sum(nil))[:32]
+}
+
+// mergeAnnotationsWithChecksum merges a checksum annotation into user-provided annotations.
+// The checksum annotation always takes precedence over user-provided values.
+func mergeAnnotationsWithChecksum(userAnnotations map[string]string, checksumKey, checksumValue string) map[string]string {
+	result := make(map[string]string, len(userAnnotations)+1)
+	maps.Copy(result, userAnnotations)
+	if checksumValue != "" {
+		result[checksumKey] = checksumValue
+	}
+	return result
+}

--- a/internal/controller/config_hash_test.go
+++ b/internal/controller/config_hash_test.go
@@ -1,0 +1,161 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+)
+
+func TestConfigDataHash_DeterministicOrder(t *testing.T) {
+	data := map[string][]byte{
+		"z-key": []byte("z-value"),
+		"a-key": []byte("a-value"),
+		"m-key": []byte("m-value"),
+	}
+
+	first := configDataHash(data)
+	for i := range 100 {
+		got := configDataHash(data)
+		if got != first {
+			t.Fatalf("configDataHash produced different results: %q vs %q (iteration %d)", first, got, i)
+		}
+	}
+}
+
+func TestConfigDataHash_DifferentContent_DifferentHash(t *testing.T) {
+	data1 := map[string][]byte{"key": []byte("value1")}
+	data2 := map[string][]byte{"key": []byte("value2")}
+
+	h1 := configDataHash(data1)
+	h2 := configDataHash(data2)
+
+	if h1 == h2 {
+		t.Fatalf("expected different hashes for different content, got %q", h1)
+	}
+}
+
+func TestConfigDataHash_DifferentKey_DifferentHash(t *testing.T) {
+	data1 := map[string][]byte{"key1": []byte("value")}
+	data2 := map[string][]byte{"key2": []byte("value")}
+
+	h1 := configDataHash(data1)
+	h2 := configDataHash(data2)
+
+	if h1 == h2 {
+		t.Fatalf("expected different hashes for different keys, got %q", h1)
+	}
+}
+
+func TestConfigDataHash_NilMap_ReturnsEmpty(t *testing.T) {
+	got := configDataHash(nil)
+	if got != "" {
+		t.Fatalf("expected empty string for nil input, got %q", got)
+	}
+}
+
+func TestConfigDataHash_EmptyMap_ReturnsEmpty(t *testing.T) {
+	got := configDataHash(map[string][]byte{})
+	if got != "" {
+		t.Fatalf("expected empty string for empty input, got %q", got)
+	}
+}
+
+func TestConfigStringDataHash_DeterministicOrder(t *testing.T) {
+	data := map[string]string{
+		"z-key": "z-value",
+		"a-key": "a-value",
+		"m-key": "m-value",
+	}
+
+	first := configStringDataHash(data)
+	for i := range 100 {
+		got := configStringDataHash(data)
+		if got != first {
+			t.Fatalf("configStringDataHash produced different results: %q vs %q (iteration %d)", first, got, i)
+		}
+	}
+}
+
+func TestConfigStringDataHash_NilMap_ReturnsEmpty(t *testing.T) {
+	got := configStringDataHash(nil)
+	if got != "" {
+		t.Fatalf("expected empty string for nil input, got %q", got)
+	}
+}
+
+func TestConfigDataHash_Length(t *testing.T) {
+	data := map[string][]byte{"key": []byte("value")}
+	got := configDataHash(data)
+	if len(got) != 32 {
+		t.Fatalf("expected hash length 32, got %d (%q)", len(got), got)
+	}
+}
+
+func TestMergeAnnotationsWithChecksum_PreservesUserAnnotations(t *testing.T) {
+	user := map[string]string{
+		"app.io/custom": "value",
+		"another":       "annotation",
+	}
+
+	result := mergeAnnotationsWithChecksum(user, "checksum/config", "abc123")
+
+	if result["app.io/custom"] != "value" {
+		t.Fatalf("expected user annotation preserved, got %q", result["app.io/custom"])
+	}
+	if result["another"] != "annotation" {
+		t.Fatalf("expected user annotation preserved, got %q", result["another"])
+	}
+	if result["checksum/config"] != "abc123" {
+		t.Fatalf("expected checksum annotation, got %q", result["checksum/config"])
+	}
+}
+
+func TestMergeAnnotationsWithChecksum_OverwritesUserChecksum(t *testing.T) {
+	user := map[string]string{
+		"checksum/config": "user-value",
+	}
+
+	result := mergeAnnotationsWithChecksum(user, "checksum/config", "controller-value")
+
+	if result["checksum/config"] != "controller-value" {
+		t.Fatalf("expected controller checksum to take precedence, got %q", result["checksum/config"])
+	}
+}
+
+func TestMergeAnnotationsWithChecksum_NilAnnotations(t *testing.T) {
+	result := mergeAnnotationsWithChecksum(nil, "checksum/config", "abc123")
+
+	if result["checksum/config"] != "abc123" {
+		t.Fatalf("expected checksum annotation, got %q", result["checksum/config"])
+	}
+	if len(result) != 1 {
+		t.Fatalf("expected 1 annotation, got %d", len(result))
+	}
+}
+
+func TestMergeAnnotationsWithChecksum_EmptyChecksum(t *testing.T) {
+	user := map[string]string{"app/custom": "value"}
+
+	result := mergeAnnotationsWithChecksum(user, "checksum/config", "")
+
+	if _, ok := result["checksum/config"]; ok {
+		t.Fatal("expected no checksum annotation for empty value")
+	}
+	if result["app/custom"] != "value" {
+		t.Fatalf("expected user annotation preserved, got %q", result["app/custom"])
+	}
+}


### PR DESCRIPTION
## Summary

- Added `configDataHash` / `configStringDataHash` helpers that compute deterministic SHA-256 checksums of Secret/ConfigMap data (sorted keys, hex-encoded, 32 chars)
- Added `mergeAnnotationsWithChecksum` to merge controller checksums with user annotations (controller always wins)
- All 4 components now include checksum annotations on pod templates:

| Component | Annotation | Data Source |
|---|---|---|
| Server | `checksum/config` | Config Secret `.Data` |
| Dashboard | `checksum/config` | ConfigMap `.Data` |
| TimeSeries | `checksum/auth` | Auth Secret `.Data` |
| Search | `checksum/auth` | Auth Secret `.Data` |

- If Secret/ConfigMap is missing when building the workload, the function returns a wrapped error (no silent skip)
- User annotations from CR spec are preserved alongside checksums
- Reconciliation ordering unchanged (config created before workloads)

## Test plan

- [x] `TestConfigDataHash_DeterministicOrder` — same map produces identical hash
- [x] `TestConfigDataHash_DifferentContent_DifferentHash` — changed value produces different hash
- [x] `TestConfigDataHash_DifferentKey_DifferentHash` — changed key produces different hash
- [x] `TestConfigDataHash_NilMap_ReturnsEmpty`
- [x] `TestConfigDataHash_EmptyMap_ReturnsEmpty`
- [x] `TestConfigDataHash_Length` — hash is 32 chars
- [x] `TestConfigStringDataHash_DeterministicOrder`
- [x] `TestConfigStringDataHash_NilMap_ReturnsEmpty`
- [x] `TestMergeAnnotationsWithChecksum_PreservesUserAnnotations`
- [x] `TestMergeAnnotationsWithChecksum_OverwritesUserChecksum`
- [x] `TestMergeAnnotationsWithChecksum_NilAnnotations`
- [x] `TestMergeAnnotationsWithChecksum_EmptyChecksum`
- [x] `make fmt && make vet && make lint` — 0 issues
- [x] `make test` — all tests pass
- [x] `go test -race` — no data races

Closes #54