### PR TITLE
fix: pin init container image and make it configurable

### DIFF
--- a/api/v1alpha1/axonopsserver_types.go
+++ b/api/v1alpha1/axonopsserver_types.go
@@ -72,6 +72,11 @@ type AxonOpsServerSpec struct {
 	// TLS configures cert-manager TLS certificate issuance for internal components.
 	// +optional
 	TLS AxonOpsTLSConfig `json:"tls,omitempty"`
+
+	// InitImage is the container image used for init containers (e.g., volume permission fixing).
+	// Defaults to "busybox:1.37.0" if not specified. Must be pinned to a specific version.
+	// +optional
+	InitImage string `json:"initImage,omitempty"`
 }
 
 // AxonOpsServerStatus defines the observed state of AxonOpsServer.

--- a/config/crd/bases/core.axonops.com_axonopsservers.yaml
+++ b/config/crd/bases/core.axonops.com_axonopsservers.yaml
@@ -158,6 +158,11 @@ spec:
                     description: StorageConfig defines persistent storage configuration
                     x-kubernetes-preserve-unknown-fields: true
                 type: object
+              initImage:
+                description: |-
+                  InitImage is the container image used for init containers (e.g., volume permission fixing).
+                  Defaults to "busybox:1.37.0" if not specified. Must be pinned to a specific version.
+                type: string
               search:
                 description: Search configures the axondb-search component
                 properties:

--- a/internal/controller/axonopsserver_controller.go
+++ b/internal/controller/axonopsserver_controller.go
@@ -78,6 +78,9 @@ const (
 	defaultDashboardImage  = "registry.axonops.com/axonops-public/axonops-docker/axon-dash"
 	defaultDashboardTag    = "2.0.28"
 
+	// Default init container image (pinned version — do not use :latest)
+	defaultInitImage = "busybox:1.37.0"
+
 	// Default heap sizes
 	defaultTimeseriesHeapSize = "1024M"
 	defaultSearchHeapSize     = "2g"
@@ -1992,7 +1995,7 @@ func (r *AxonOpsServerReconciler) ensureSearchStatefulSet(ctx context.Context, s
 					InitContainers: []corev1.Container{
 						{
 							Name:            "fsgroup-volume",
-							Image:           "busybox:latest",
+							Image:           resolveInitImage(server),
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							Command:         []string{"sh", "-c"},
 							Args:            []string{"chown -R 999:999 /var/lib/opensearch"},
@@ -2784,7 +2787,7 @@ func (r *AxonOpsServerReconciler) ensureServerStatefulSet(ctx context.Context, s
 					InitContainers: []corev1.Container{
 						{
 							Name:            "fsgroup-volume",
-							Image:           "busybox:latest",
+							Image:           resolveInitImage(server),
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							Command:         []string{"sh", "-c"},
 							Args:            []string{fmt.Sprintf("chown -R %d:%d /var/lib/axonops", serverUserID, serverGroupID)},
@@ -3570,6 +3573,16 @@ func (r *AxonOpsServerReconciler) ensureServerApiGateway(ctx context.Context, se
 // ptr returns a pointer to the given value
 func ptr[T any](v T) *T {
 	return &v
+}
+
+// resolveInitImage returns the init container image to use. If the user
+// specified one in the CRD spec, it is used; otherwise the pinned default
+// is returned.
+func resolveInitImage(server *corev1alpha1.AxonOpsServer) string {
+	if server.Spec.InitImage != "" {
+		return server.Spec.InitImage
+	}
+	return defaultInitImage
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/init_image_test.go
+++ b/internal/controller/init_image_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"strings"
+	"testing"
+
+	corev1alpha1 "github.com/axonops/axonops-operator/api/v1alpha1"
+)
+
+func TestResolveInitImage_DefaultIsPinned(t *testing.T) {
+	server := &corev1alpha1.AxonOpsServer{}
+
+	got := resolveInitImage(server)
+
+	if got != defaultInitImage {
+		t.Fatalf("expected default %q, got %q", defaultInitImage, got)
+	}
+	if strings.HasSuffix(got, ":latest") {
+		t.Fatalf("default init image must not use :latest, got %q", got)
+	}
+	if !strings.Contains(got, ":") {
+		t.Fatalf("default init image must include a tag, got %q", got)
+	}
+}
+
+func TestResolveInitImage_CustomImage(t *testing.T) {
+	server := &corev1alpha1.AxonOpsServer{
+		Spec: corev1alpha1.AxonOpsServerSpec{
+			InitImage: "myregistry.io/busybox:1.36.0",
+		},
+	}
+
+	got := resolveInitImage(server)
+
+	if got != "myregistry.io/busybox:1.36.0" {
+		t.Fatalf("expected custom image, got %q", got)
+	}
+}
+
+func TestResolveInitImage_EmptyFallsBackToDefault(t *testing.T) {
+	server := &corev1alpha1.AxonOpsServer{
+		Spec: corev1alpha1.AxonOpsServerSpec{
+			InitImage: "",
+		},
+	}
+
+	got := resolveInitImage(server)
+
+	if got != defaultInitImage {
+		t.Fatalf("expected default %q for empty spec, got %q", defaultInitImage, got)
+	}
+}
+
+func TestDefaultInitImage_NotLatest(t *testing.T) {
+	if strings.HasSuffix(defaultInitImage, ":latest") {
+		t.Fatalf("defaultInitImage must not use :latest tag, got %q", defaultInitImage)
+	}
+}


### PR DESCRIPTION
## Summary

- Replaced hardcoded `busybox:latest` in Search and Server StatefulSet init containers with a pinned default `busybox:1.37.0`
- Added `spec.initImage` field to `AxonOpsServer` CRD for user customization
- Added `resolveInitImage` helper that returns the user-specified image or the pinned default
- Regenerated CRD manifests and DeepCopy methods

### Before
```yaml
# Hardcoded in controller, not configurable
image: busybox:latest
```

### After
```yaml
# Default (no spec.initImage set)
image: busybox:1.37.0

# Custom (spec.initImage set)
apiVersion: core.axonops.com/v1alpha1
kind: AxonOpsServer
spec:
  initImage: "myregistry.io/busybox:1.36.0"
```

## Test plan

- [x] `TestResolveInitImage_DefaultIsPinned` — default is `busybox:1.37.0`, not `:latest`
- [x] `TestResolveInitImage_CustomImage` — custom image from spec is used
- [x] `TestResolveInitImage_EmptyFallsBackToDefault` — empty string falls back to default
- [x] `TestDefaultInitImage_NotLatest` — constant does not use `:latest`
- [x] `make fmt && make vet && make lint` — 0 issues
- [x] `make test` — all tests pass

Closes #41