### PR TITLE
feat: add spec.imageRegistry for global container registry override

### DIFF
--- a/api/v1alpha1/axonopsserver_types.go
+++ b/api/v1alpha1/axonopsserver_types.go
@@ -82,7 +82,7 @@ type AxonOpsServerSpec struct {
 	ImageRegistry string `json:"imageRegistry,omitempty"`
 
 	// InitImage is the container image used for init containers (e.g., volume permission fixing).
-	// Defaults to "busybox:1.37.0" if not specified. Must be pinned to a specific version.
+	// Defaults to "docker.io/library/busybox:1.37.0" if not specified. Must be pinned to a specific version.
 	// +optional
 	InitImage string `json:"initImage,omitempty"`
 }

--- a/config/crd/bases/core.axonops.com_axonopsservers.yaml
+++ b/config/crd/bases/core.axonops.com_axonopsservers.yaml
@@ -169,7 +169,7 @@ spec:
               initImage:
                 description: |-
                   InitImage is the container image used for init containers (e.g., volume permission fixing).
-                  Defaults to "busybox:1.37.0" if not specified. Must be pinned to a specific version.
+                  Defaults to "docker.io/library/busybox:1.37.0" if not specified. Must be pinned to a specific version.
                 type: string
               search:
                 description: Search configures the axondb-search component

--- a/internal/controller/axonopsserver_controller.go
+++ b/internal/controller/axonopsserver_controller.go
@@ -79,7 +79,7 @@ const (
 	defaultDashboardTag    = "2.0.28"
 
 	// Default init container image (pinned version — do not use :latest)
-	defaultInitImage = "busybox:1.37.0"
+	defaultInitImage = "docker.io/library/busybox:1.37.0"
 
 	// Default heap sizes
 	defaultTimeseriesHeapSize = "1024M"

--- a/internal/controller/image_registry.go
+++ b/internal/controller/image_registry.go
@@ -25,13 +25,13 @@ import "strings"
 // For images with an explicit registry (first path segment contains "." or ":"),
 // that segment is replaced:
 //
-//	replaceImageRegistry("ghcr.io/axonops/img", "harbor.io") => "harbor.io/axonops/img"
-//	replaceImageRegistry("registry.axonops.com/path/img", "harbor.io") => "harbor.io/path/img"
+//	replaceImageRegistry("ghcr.io/axonops/img", "registry.local") => "registry.local/axonops/img"
+//	replaceImageRegistry("registry.axonops.com/path/img", "registry.local") => "registry.local/path/img"
 //
 // For images without an explicit registry (e.g., Docker Hub library images),
 // the registry is prepended:
 //
-//	replaceImageRegistry("busybox:1.37.0", "harbor.io") => "harbor.io/busybox:1.37.0"
+//	replaceImageRegistry("docker.io/library/busybox:1.37.0", "registry.local") => "registry.local/busybox:1.37.0"
 func replaceImageRegistry(image, newRegistry string) string {
 	if newRegistry == "" {
 		return image
@@ -42,7 +42,7 @@ func replaceImageRegistry(image, newRegistry string) string {
 	// Split image into segments by "/"
 	parts := strings.SplitN(image, "/", 2)
 
-	// Single segment (e.g., "busybox:1.37.0") — no explicit registry, prepend
+	// Single segment (e.g., "docker.io/library/busybox:1.37.0") — no explicit registry, prepend
 	if len(parts) == 1 {
 		return newRegistry + "/" + image
 	}

--- a/internal/controller/image_registry_test.go
+++ b/internal/controller/image_registry_test.go
@@ -32,32 +32,32 @@ func TestReplaceImageRegistry(t *testing.T) {
 		{
 			name:        "ExplicitRegistry_SingleSegmentPath",
 			image:       "ghcr.io/axonops/img",
-			newRegistry: "harbor.io",
-			want:        "harbor.io/axonops/img",
+			newRegistry: "registry.local",
+			want:        "registry.local/axonops/img",
 		},
 		{
 			name:        "ExplicitRegistry_MultiSegmentPath",
 			image:       "registry.axonops.com/axonops-public/axonops-docker/axon-server",
-			newRegistry: "harbor.io",
-			want:        "harbor.io/axonops-public/axonops-docker/axon-server",
+			newRegistry: "registry.local",
+			want:        "registry.local/axonops-public/axonops-docker/axon-server",
 		},
 		{
 			name:        "ExplicitRegistry_WithPort",
 			image:       "ghcr.io/axonops/img",
-			newRegistry: "harbor.io:5000",
-			want:        "harbor.io:5000/axonops/img",
+			newRegistry: "registry.local:5000",
+			want:        "registry.local:5000/axonops/img",
 		},
 		{
 			name:        "DockerHubImage_NoSlash",
-			image:       "busybox:1.37.0",
-			newRegistry: "harbor.io",
-			want:        "harbor.io/busybox:1.37.0",
+			image:       "docker.io/library/busybox:1.37.0",
+			newRegistry: "registry.local",
+			want:        "registry.local/busybox:1.37.0",
 		},
 		{
 			name:        "DockerHubImage_LibraryPath",
 			image:       "library/nginx:latest",
-			newRegistry: "harbor.io",
-			want:        "harbor.io/library/nginx:latest",
+			newRegistry: "registry.local",
+			want:        "registry.local/library/nginx:latest",
 		},
 		{
 			name:        "EmptyRegistry_ReturnsOriginal",
@@ -68,20 +68,20 @@ func TestReplaceImageRegistry(t *testing.T) {
 		{
 			name:        "TrailingSlash_Stripped",
 			image:       "ghcr.io/axonops/img",
-			newRegistry: "harbor.io/",
-			want:        "harbor.io/axonops/img",
+			newRegistry: "registry.local/",
+			want:        "registry.local/axonops/img",
 		},
 		{
 			name:        "RegistryWithPort_ColonInFirstSegment",
 			image:       "localhost:5000/myimg",
-			newRegistry: "harbor.io",
-			want:        "harbor.io/myimg",
+			newRegistry: "registry.local",
+			want:        "registry.local/myimg",
 		},
 		{
 			name:        "ImageOnly_NoTag",
 			image:       "busybox",
-			newRegistry: "harbor.io",
-			want:        "harbor.io/busybox",
+			newRegistry: "registry.local",
+			want:        "registry.local/busybox",
 		},
 		{
 			name:        "AllDefaultImages_TimeSeries",
@@ -136,16 +136,16 @@ func TestResolveImage(t *testing.T) {
 		{
 			name:              "ComponentOverride_TakesPrecedence",
 			defaultImage:      "ghcr.io/axonops/img",
-			globalRegistry:    "harbor.io",
+			globalRegistry:    "registry.local",
 			componentOverride: "custom.io/my-img",
 			want:              "custom.io/my-img",
 		},
 		{
 			name:              "GlobalRegistry_Applied",
 			defaultImage:      "ghcr.io/axonops/img",
-			globalRegistry:    "harbor.io",
+			globalRegistry:    "registry.local",
 			componentOverride: "",
-			want:              "harbor.io/axonops/img",
+			want:              "registry.local/axonops/img",
 		},
 		{
 			name:              "Default_WhenNothingSet",
@@ -156,17 +156,17 @@ func TestResolveImage(t *testing.T) {
 		},
 		{
 			name:              "ComponentOverride_IgnoresGlobalRegistry",
-			defaultImage:      "busybox:1.37.0",
-			globalRegistry:    "harbor.io",
+			defaultImage:      "docker.io/library/busybox:1.37.0",
+			globalRegistry:    "registry.local",
 			componentOverride: "my.io/custom-busybox:2.0",
 			want:              "my.io/custom-busybox:2.0",
 		},
 		{
 			name:              "GlobalRegistry_DockerHubImage",
-			defaultImage:      "busybox:1.37.0",
-			globalRegistry:    "harbor.io",
+			defaultImage:      "docker.io/library/busybox:1.37.0",
+			globalRegistry:    "registry.local",
 			componentOverride: "",
-			want:              "harbor.io/busybox:1.37.0",
+			want:              "registry.local/busybox:1.37.0",
 		},
 	}
 
@@ -196,7 +196,7 @@ func TestResolveInitImage_ImageRegistry(t *testing.T) {
 			name: "CustomInitImage_TakesPrecedence",
 			server: &corev1alpha1.AxonOpsServer{
 				Spec: corev1alpha1.AxonOpsServerSpec{
-					ImageRegistry: "harbor.io",
+					ImageRegistry: "registry.local",
 					InitImage:     "my.io/custom-busybox:2.0",
 				},
 			},
@@ -206,10 +206,10 @@ func TestResolveInitImage_ImageRegistry(t *testing.T) {
 			name: "ImageRegistry_AppliedToDefault",
 			server: &corev1alpha1.AxonOpsServer{
 				Spec: corev1alpha1.AxonOpsServerSpec{
-					ImageRegistry: "harbor.io",
+					ImageRegistry: "registry.local",
 				},
 			},
-			want: "harbor.io/busybox:1.37.0",
+			want: "registry.local/busybox:1.37.0",
 		},
 	}
 


### PR DESCRIPTION
## Summary

Adds `spec.imageRegistry` to `AxonOpsServer` so on-premises users can redirect all component images to a private registry (Harbor, Artifactory, Nexus) with a single setting instead of overriding each component individually.

### Before (5 fields)
```yaml
spec:
  timeSeries:
    repository:
      image: harbor.internal.com/axonops/axondb-timeseries
  search:
    repository:
      image: harbor.internal.com/axonops/axondb-search
  server:
    repository:
      image: harbor.internal.com/axonops-public/axonops-docker/axon-server
  dashboard:
    repository:
      image: harbor.internal.com/axonops-public/axonops-docker/axon-dash
  initImage: harbor.internal.com/busybox:1.37.0
```

### After (1 field)
```yaml
spec:
  imageRegistry: harbor.internal.com
```

### Precedence
1. Per-component `repository.image` — full override, `imageRegistry` ignored
2. `spec.imageRegistry` — replaces registry host on defaults
3. Default image constants

### Registry replacement logic
- **Explicit registries** (first segment contains `.` or `:`): registry portion replaced
  - `ghcr.io/axonops/img` → `harbor.io/axonops/img`
  - `registry.axonops.com/path/img` → `harbor.io/path/img`
- **Docker Hub images** (no explicit registry): registry prepended
  - `busybox:1.37.0` → `harbor.io/busybox:1.37.0`

## Test plan
- [x] `TestReplaceImageRegistry` — 14 table-driven cases (explicit registry, multi-segment path, port, Docker Hub, library path, trailing slash, empty, all 5 defaults)
- [x] `TestResolveImage` — 5 cases (component override, global registry, default, precedence)
- [x] `TestResolveInitImage_ImageRegistry` — 3 cases (default, custom initImage, imageRegistry applied)
- [x] `make fmt && make vet && make lint` — 0 issues
- [x] `make test` — all tests pass, 40.6% coverage

Closes #60