### PR TITLE
fix: replace bare type assertions with errors.As and remove bubble sort

### DIFF
--- a/internal/controller/alerts/axonopsadaptiverepair_controller.go
+++ b/internal/controller/alerts/axonopsadaptiverepair_controller.go
@@ -18,6 +18,7 @@ package alerts
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"time"
@@ -99,7 +100,8 @@ func (r *AxonOpsAdaptiveRepairReconciler) Reconcile(ctx context.Context, req ctr
 	if err != nil {
 		log.Error(err, "Failed to get adaptive repair settings from AxonOps")
 		r.setFailedCondition(ctx, repair, ReasonAPIError, fmt.Sprintf("Failed to get adaptive repair settings: %v", err))
-		if apiErr, ok := err.(*axonops.APIError); ok && apiErr.IsRetryable() {
+		var apiErr *axonops.APIError
+		if errors.As(err, &apiErr) && apiErr.IsRetryable() {
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 		}
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
@@ -119,7 +121,8 @@ func (r *AxonOpsAdaptiveRepairReconciler) Reconcile(ctx context.Context, req ctr
 	if err := apiClient.UpdateAdaptiveRepair(ctx, repair.Spec.ClusterType, repair.Spec.ClusterName, desired); err != nil {
 		log.Error(err, "Failed to update adaptive repair settings")
 		r.setFailedCondition(ctx, repair, ReasonAPIError, fmt.Sprintf("Failed to update adaptive repair settings: %v", err))
-		if apiErr, ok := err.(*axonops.APIError); ok && apiErr.IsRetryable() {
+		var apiErr *axonops.APIError
+		if errors.As(err, &apiErr) && apiErr.IsRetryable() {
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 		}
 		return ctrl.Result{}, nil

--- a/internal/controller/alerts/axonopsalertendpoint_controller.go
+++ b/internal/controller/alerts/axonopsalertendpoint_controller.go
@@ -18,6 +18,7 @@ package alerts
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"maps"
 	"time"
@@ -218,7 +219,8 @@ func (r *AxonOpsAlertEndpointReconciler) handleDeletion(ctx context.Context, end
 	if endpoint.Status.SyncedIntegrationID != "" {
 		if err := apiClient.DeleteIntegration(ctx, endpoint.Spec.ClusterType, endpoint.Spec.ClusterName, endpoint.Status.SyncedIntegrationID); err != nil {
 			log.Error(err, "Failed to delete integration from AxonOps", "integrationID", endpoint.Status.SyncedIntegrationID)
-			if apiErr, ok := err.(*axonops.APIError); ok && apiErr.IsRetryable() {
+			var apiErr *axonops.APIError
+			if errors.As(err, &apiErr) && apiErr.IsRetryable() {
 				return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 			}
 			// Non-retryable error, proceed with finalizer removal

--- a/internal/controller/alerts/axonopsalertroute_controller.go
+++ b/internal/controller/alerts/axonopsalertroute_controller.go
@@ -18,6 +18,7 @@ package alerts
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -266,7 +267,8 @@ func (r *AxonOpsAlertRouteReconciler) handleDeletion(ctx context.Context, route 
 	integrations, err := apiClient.GetIntegrations(ctx, route.Spec.ClusterType, route.Spec.ClusterName)
 	if err != nil {
 		log.Error(err, "Failed to get integrations for cleanup")
-		if apiErr, ok := err.(*axonops.APIError); ok && apiErr.IsRetryable() {
+		var apiErr *axonops.APIError
+		if errors.As(err, &apiErr) && apiErr.IsRetryable() {
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 		}
 		// Non-retryable error, proceed with finalizer removal
@@ -286,7 +288,8 @@ func (r *AxonOpsAlertRouteReconciler) handleDeletion(ctx context.Context, route 
 				if err := apiClient.RemoveIntegrationRoute(ctx, route.Spec.ClusterType, route.Spec.ClusterName,
 					apiRouteType, route.Spec.Severity, integrationID); err != nil {
 					log.Error(err, "Failed to remove route from AxonOps", "integrationID", integrationID)
-					if apiErr, ok := err.(*axonops.APIError); ok && apiErr.IsRetryable() {
+					var apiErr *axonops.APIError
+					if errors.As(err, &apiErr) && apiErr.IsRetryable() {
 						return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 					}
 				} else {

--- a/internal/controller/alerts/axonopshealthcheckhttp_controller.go
+++ b/internal/controller/alerts/axonopshealthcheckhttp_controller.go
@@ -18,6 +18,7 @@ package alerts
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -126,7 +127,8 @@ func (r *AxonOpsHealthcheckHTTPReconciler) Reconcile(ctx context.Context, req ct
 	if err := apiClient.UpdateHealthchecks(ctx, healthcheck.Spec.ClusterType, healthcheck.Spec.ClusterName, allHealthchecks); err != nil {
 		log.Error(err, "Failed to update healthchecks")
 		r.setFailedCondition(ctx, healthcheck, ReasonAPIError, fmt.Sprintf("Failed to update healthchecks: %v", err))
-		if apiErr, ok := err.(*axonops.APIError); ok && apiErr.IsRetryable() {
+		var apiErr *axonops.APIError
+		if errors.As(err, &apiErr) && apiErr.IsRetryable() {
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 		}
 		return ctrl.Result{}, nil
@@ -184,7 +186,8 @@ func (r *AxonOpsHealthcheckHTTPReconciler) handleDeletion(ctx context.Context, h
 		// Get all healthchecks
 		allHealthchecks, err := apiClient.GetHealthchecks(ctx, healthcheck.Spec.ClusterType, healthcheck.Spec.ClusterName)
 		if err != nil {
-			if apiErr, ok := err.(*axonops.APIError); ok && apiErr.StatusCode == 404 {
+			var apiErr *axonops.APIError
+			if errors.As(err, &apiErr) && apiErr.StatusCode == 404 {
 				log.Info("Healthchecks not found, proceeding with finalizer removal")
 			} else {
 				log.Error(err, "Failed to get healthchecks for deletion")
@@ -202,7 +205,8 @@ func (r *AxonOpsHealthcheckHTTPReconciler) handleDeletion(ctx context.Context, h
 
 			// Update via bulk PUT
 			if err := apiClient.UpdateHealthchecks(ctx, healthcheck.Spec.ClusterType, healthcheck.Spec.ClusterName, allHealthchecks); err != nil {
-				if apiErr, ok := err.(*axonops.APIError); ok && apiErr.IsRetryable() {
+				var apiErr *axonops.APIError
+				if errors.As(err, &apiErr) && apiErr.IsRetryable() {
 					return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 				}
 				log.Error(err, "Failed to delete healthcheck from AxonOps")

--- a/internal/controller/alerts/axonopshealthcheckshell_controller.go
+++ b/internal/controller/alerts/axonopshealthcheckshell_controller.go
@@ -18,6 +18,7 @@ package alerts
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -126,7 +127,8 @@ func (r *AxonOpsHealthcheckShellReconciler) Reconcile(ctx context.Context, req c
 	if err := apiClient.UpdateHealthchecks(ctx, healthcheck.Spec.ClusterType, healthcheck.Spec.ClusterName, allHealthchecks); err != nil {
 		log.Error(err, "Failed to update healthchecks")
 		r.setFailedCondition(ctx, healthcheck, ReasonAPIError, fmt.Sprintf("Failed to update healthchecks: %v", err))
-		if apiErr, ok := err.(*axonops.APIError); ok && apiErr.IsRetryable() {
+		var apiErr *axonops.APIError
+		if errors.As(err, &apiErr) && apiErr.IsRetryable() {
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 		}
 		return ctrl.Result{}, nil
@@ -184,7 +186,8 @@ func (r *AxonOpsHealthcheckShellReconciler) handleDeletion(ctx context.Context, 
 		// Get all healthchecks
 		allHealthchecks, err := apiClient.GetHealthchecks(ctx, healthcheck.Spec.ClusterType, healthcheck.Spec.ClusterName)
 		if err != nil {
-			if apiErr, ok := err.(*axonops.APIError); ok && apiErr.StatusCode == 404 {
+			var apiErr *axonops.APIError
+			if errors.As(err, &apiErr) && apiErr.StatusCode == 404 {
 				log.Info("Healthchecks not found, proceeding with finalizer removal")
 			} else {
 				log.Error(err, "Failed to get healthchecks for deletion")
@@ -202,7 +205,8 @@ func (r *AxonOpsHealthcheckShellReconciler) handleDeletion(ctx context.Context, 
 
 			// Update via bulk PUT
 			if err := apiClient.UpdateHealthchecks(ctx, healthcheck.Spec.ClusterType, healthcheck.Spec.ClusterName, allHealthchecks); err != nil {
-				if apiErr, ok := err.(*axonops.APIError); ok && apiErr.IsRetryable() {
+				var apiErr *axonops.APIError
+				if errors.As(err, &apiErr) && apiErr.IsRetryable() {
 					return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 				}
 				log.Error(err, "Failed to delete healthcheck from AxonOps")

--- a/internal/controller/alerts/axonopshealthchecktcp_controller.go
+++ b/internal/controller/alerts/axonopshealthchecktcp_controller.go
@@ -18,6 +18,7 @@ package alerts
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -126,7 +127,8 @@ func (r *AxonOpsHealthcheckTCPReconciler) Reconcile(ctx context.Context, req ctr
 	if err := apiClient.UpdateHealthchecks(ctx, healthcheck.Spec.ClusterType, healthcheck.Spec.ClusterName, allHealthchecks); err != nil {
 		log.Error(err, "Failed to update healthchecks")
 		r.setFailedCondition(ctx, healthcheck, ReasonAPIError, fmt.Sprintf("Failed to update healthchecks: %v", err))
-		if apiErr, ok := err.(*axonops.APIError); ok && apiErr.IsRetryable() {
+		var apiErr *axonops.APIError
+		if errors.As(err, &apiErr) && apiErr.IsRetryable() {
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 		}
 		return ctrl.Result{}, nil
@@ -184,7 +186,8 @@ func (r *AxonOpsHealthcheckTCPReconciler) handleDeletion(ctx context.Context, he
 		// Get all healthchecks
 		allHealthchecks, err := apiClient.GetHealthchecks(ctx, healthcheck.Spec.ClusterType, healthcheck.Spec.ClusterName)
 		if err != nil {
-			if apiErr, ok := err.(*axonops.APIError); ok && apiErr.StatusCode == 404 {
+			var apiErr *axonops.APIError
+			if errors.As(err, &apiErr) && apiErr.StatusCode == 404 {
 				log.Info("Healthchecks not found, proceeding with finalizer removal")
 			} else {
 				log.Error(err, "Failed to get healthchecks for deletion")
@@ -202,7 +205,8 @@ func (r *AxonOpsHealthcheckTCPReconciler) handleDeletion(ctx context.Context, he
 
 			// Update via bulk PUT
 			if err := apiClient.UpdateHealthchecks(ctx, healthcheck.Spec.ClusterType, healthcheck.Spec.ClusterName, allHealthchecks); err != nil {
-				if apiErr, ok := err.(*axonops.APIError); ok && apiErr.IsRetryable() {
+				var apiErr *axonops.APIError
+				if errors.As(err, &apiErr) && apiErr.IsRetryable() {
 					return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 				}
 				log.Error(err, "Failed to delete healthcheck from AxonOps")

--- a/internal/controller/alerts/axonopslogalert_controller.go
+++ b/internal/controller/alerts/axonopslogalert_controller.go
@@ -18,6 +18,7 @@ package alerts
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -135,7 +136,8 @@ func (r *AxonOpsLogAlertReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		}
 
 		// Check if error is retryable
-		if apiErr, ok := err.(*axonops.APIError); ok && apiErr.IsRetryable() {
+		var apiErr *axonops.APIError
+		if errors.As(err, &apiErr) && apiErr.IsRetryable() {
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 		}
 		return ctrl.Result{}, nil
@@ -202,7 +204,8 @@ func (r *AxonOpsLogAlertReconciler) handleDeletion(ctx context.Context, alert *a
 		if err := apiClient.DeleteMetricAlertRule(ctx, alert.Spec.ClusterType, alert.Spec.ClusterName, alert.Status.SyncedAlertID); err != nil {
 			log.Error(err, "Failed to delete alert rule from AxonOps", "alertID", alert.Status.SyncedAlertID)
 			// Check for retryable API errors
-			if apiErr, ok := err.(*axonops.APIError); ok && apiErr.IsRetryable() {
+			var apiErr *axonops.APIError
+			if errors.As(err, &apiErr) && apiErr.IsRetryable() {
 				return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 			}
 			// For non-retryable errors (like 404), proceed to remove the finalizer

--- a/internal/controller/alerts/axonopsmetricalert_controller.go
+++ b/internal/controller/alerts/axonopsmetricalert_controller.go
@@ -18,6 +18,7 @@ package alerts
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -156,7 +157,8 @@ func (r *AxonOpsMetricAlertReconciler) Reconcile(ctx context.Context, req ctrl.R
 		}
 
 		// Check if error is retryable
-		if apiErr, ok := err.(*axonops.APIError); ok && apiErr.IsRetryable() {
+		var apiErr *axonops.APIError
+		if errors.As(err, &apiErr) && apiErr.IsRetryable() {
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 		}
 		return ctrl.Result{}, nil
@@ -227,7 +229,8 @@ func (r *AxonOpsMetricAlertReconciler) handleDeletion(ctx context.Context, alert
 		if err := apiClient.DeleteMetricAlertRule(ctx, alert.Spec.ClusterType, alert.Spec.ClusterName, alert.Status.SyncedAlertID); err != nil {
 			log.Error(err, "Failed to delete alert rule from AxonOps", "alertID", alert.Status.SyncedAlertID)
 			// Check for retryable API errors
-			if apiErr, ok := err.(*axonops.APIError); ok && apiErr.IsRetryable() {
+			var apiErr *axonops.APIError
+			if errors.As(err, &apiErr) && apiErr.IsRetryable() {
 				return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 			}
 			// For non-retryable errors (like 404), proceed to remove the finalizer

--- a/internal/controller/alerts/axonopsscheduledrepair_controller.go
+++ b/internal/controller/alerts/axonopsscheduledrepair_controller.go
@@ -18,6 +18,7 @@ package alerts
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -119,7 +120,8 @@ func (r *AxonOpsScheduledRepairReconciler) Reconcile(ctx context.Context, req ct
 	if repair.Status.SyncedRepairID != "" {
 		log.Info("Deleting existing repair before recreate", "repairID", repair.Status.SyncedRepairID)
 		if err := apiClient.DeleteScheduledRepair(ctx, repair.Spec.ClusterType, repair.Spec.ClusterName, repair.Status.SyncedRepairID); err != nil {
-			if apiErr, ok := err.(*axonops.APIError); ok && apiErr.IsRetryable() {
+			var apiErr *axonops.APIError
+			if errors.As(err, &apiErr) && apiErr.IsRetryable() {
 				return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 			}
 		}
@@ -141,7 +143,8 @@ func (r *AxonOpsScheduledRepairReconciler) Reconcile(ctx context.Context, req ct
 		if err := r.Status().Update(ctx, repair); err != nil {
 			log.Error(err, "Failed to update status")
 		}
-		if apiErr, ok := err.(*axonops.APIError); ok && apiErr.IsRetryable() {
+		var apiErr *axonops.APIError
+		if errors.As(err, &apiErr) && apiErr.IsRetryable() {
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 		}
 		return ctrl.Result{}, nil
@@ -203,7 +206,8 @@ func (r *AxonOpsScheduledRepairReconciler) handleDeletion(ctx context.Context, r
 	if repair.Status.SyncedRepairID != "" {
 		if err := apiClient.DeleteScheduledRepair(ctx, repair.Spec.ClusterType, repair.Spec.ClusterName, repair.Status.SyncedRepairID); err != nil {
 			log.Error(err, "Failed to delete repair from AxonOps", "repairID", repair.Status.SyncedRepairID)
-			if apiErr, ok := err.(*axonops.APIError); ok && apiErr.IsRetryable() {
+			var apiErr *axonops.APIError
+			if errors.As(err, &apiErr) && apiErr.IsRetryable() {
 				return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 			}
 		} else {

--- a/internal/controller/backups/axonopsbackup_controller.go
+++ b/internal/controller/backups/axonopsbackup_controller.go
@@ -18,7 +18,9 @@ package backups
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -146,7 +148,8 @@ func (r *AxonOpsBackupReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	if backup.Status.SyncedBackupID != "" {
 		log.Info("Deleting existing backup before recreate", "backupID", backup.Status.SyncedBackupID)
 		if err := apiClient.DeleteScheduledSnapshot(ctx, backup.Spec.ClusterType, backup.Spec.ClusterName, backup.Status.SyncedBackupID); err != nil {
-			if apiErr, ok := err.(*axonops.APIError); ok && apiErr.IsRetryable() {
+			var apiErr *axonops.APIError
+			if errors.As(err, &apiErr) && apiErr.IsRetryable() {
 				return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 			}
 			// Non-retryable (e.g., 404) — proceed with create
@@ -167,7 +170,8 @@ func (r *AxonOpsBackupReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		if err := r.Status().Update(ctx, backup); err != nil {
 			log.Error(err, "Failed to update status")
 		}
-		if apiErr, ok := err.(*axonops.APIError); ok && apiErr.IsRetryable() {
+		var apiErr *axonops.APIError
+		if errors.As(err, &apiErr) && apiErr.IsRetryable() {
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 		}
 		return ctrl.Result{}, nil
@@ -223,7 +227,8 @@ func (r *AxonOpsBackupReconciler) handleDeletion(ctx context.Context, backup *ba
 	if backup.Status.SyncedBackupID != "" {
 		if err := apiClient.DeleteScheduledSnapshot(ctx, backup.Spec.ClusterType, backup.Spec.ClusterName, backup.Status.SyncedBackupID); err != nil {
 			log.Error(err, "Failed to delete backup from AxonOps", "backupID", backup.Status.SyncedBackupID)
-			if apiErr, ok := err.(*axonops.APIError); ok && apiErr.IsRetryable() {
+			var apiErr *axonops.APIError
+			if errors.As(err, &apiErr) && apiErr.IsRetryable() {
 				return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 			}
 		} else {
@@ -468,7 +473,7 @@ func formatRemoteConfig(config map[string]string) string {
 		keys = append(keys, k)
 	}
 	// Sort alphabetically — not required by AxonOps API but ensures hash stability
-	sortStrings(keys)
+	slices.Sort(keys)
 
 	var parts []string
 	for _, k := range keys {
@@ -489,17 +494,6 @@ func boolToString(b bool) string {
 		return trueStr
 	}
 	return falseStr
-}
-
-// sortStrings sorts a string slice in-place (avoids importing "sort" for one call)
-func sortStrings(s []string) {
-	for i := range s {
-		for j := i + 1; j < len(s); j++ {
-			if s[j] < s[i] {
-				s[i], s[j] = s[j], s[i]
-			}
-		}
-	}
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/kafka/axonopskafkaacl_controller.go
+++ b/internal/controller/kafka/axonopskafkaacl_controller.go
@@ -18,6 +18,7 @@ package kafka
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -94,7 +95,8 @@ func (r *AxonOpsKafkaACLReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	if err := apiClient.CreateKafkaACL(ctx, acl.Spec.ClusterName, aclPayload); err != nil {
 		log.Error(err, "Failed to create Kafka ACL")
 		r.setFailedCondition(ctx, acl, "CreateFailed", fmt.Sprintf("Failed to create ACL: %v", err))
-		if apiErr, ok := err.(*axonops.APIError); ok && apiErr.IsRetryable() {
+		var apiErr *axonops.APIError
+		if errors.As(err, &apiErr) && apiErr.IsRetryable() {
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 		}
 		return ctrl.Result{}, nil
@@ -147,7 +149,8 @@ func (r *AxonOpsKafkaACLReconciler) handleDeletion(ctx context.Context, acl *kaf
 		aclPayload := buildACLPayload(acl)
 		if err := apiClient.DeleteKafkaACL(ctx, acl.Spec.ClusterName, aclPayload); err != nil {
 			log.Error(err, "Failed to delete Kafka ACL")
-			if apiErr, ok := err.(*axonops.APIError); ok && apiErr.IsRetryable() {
+			var apiErr *axonops.APIError
+			if errors.As(err, &apiErr) && apiErr.IsRetryable() {
 				return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 			}
 		} else {

--- a/internal/controller/kafka/axonopskafkaconnector_controller.go
+++ b/internal/controller/kafka/axonopskafkaconnector_controller.go
@@ -18,6 +18,7 @@ package kafka
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -98,7 +99,8 @@ func (r *AxonOpsKafkaConnectorReconciler) Reconcile(ctx context.Context, req ctr
 		if err != nil {
 			log.Error(err, "Failed to create Kafka connector")
 			r.setFailedCondition(ctx, connector, "CreateFailed", fmt.Sprintf("Failed to create connector: %v", err))
-			if apiErr, ok := err.(*axonops.APIError); ok && apiErr.IsRetryable() {
+			var apiErr *axonops.APIError
+			if errors.As(err, &apiErr) && apiErr.IsRetryable() {
 				return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 			}
 			return ctrl.Result{}, nil
@@ -112,7 +114,8 @@ func (r *AxonOpsKafkaConnectorReconciler) Reconcile(ctx context.Context, req ctr
 		if err := apiClient.UpdateKafkaConnectorConfig(ctx, connector.Spec.ClusterName, connector.Spec.ConnectClusterName, connector.Spec.Name, connector.Spec.Config); err != nil {
 			log.Error(err, "Failed to update Kafka connector config")
 			r.setFailedCondition(ctx, connector, "UpdateFailed", fmt.Sprintf("Failed to update connector config: %v", err))
-			if apiErr, ok := err.(*axonops.APIError); ok && apiErr.IsRetryable() {
+			var apiErr *axonops.APIError
+			if errors.As(err, &apiErr) && apiErr.IsRetryable() {
 				return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 			}
 			return ctrl.Result{}, nil
@@ -167,7 +170,8 @@ func (r *AxonOpsKafkaConnectorReconciler) handleDeletion(ctx context.Context, co
 	if connector.Status.Synced {
 		if err := apiClient.DeleteKafkaConnector(ctx, connector.Spec.ClusterName, connector.Spec.ConnectClusterName, connector.Spec.Name); err != nil {
 			log.Error(err, "Failed to delete Kafka connector")
-			if apiErr, ok := err.(*axonops.APIError); ok && apiErr.IsRetryable() {
+			var apiErr *axonops.APIError
+			if errors.As(err, &apiErr) && apiErr.IsRetryable() {
 				return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 			}
 		} else {

--- a/internal/controller/kafka/axonopskafkatopic_controller.go
+++ b/internal/controller/kafka/axonopskafkatopic_controller.go
@@ -18,6 +18,7 @@ package kafka
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -102,7 +103,8 @@ func (r *AxonOpsKafkaTopicReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		if err := apiClient.CreateKafkaTopic(ctx, topic.Spec.ClusterName, createReq); err != nil {
 			log.Error(err, "Failed to create Kafka topic")
 			r.setFailedCondition(ctx, topic, "CreateFailed", fmt.Sprintf("Failed to create topic: %v", err))
-			if apiErr, ok := err.(*axonops.APIError); ok && apiErr.IsRetryable() {
+			var apiErr *axonops.APIError
+			if errors.As(err, &apiErr) && apiErr.IsRetryable() {
 				return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 			}
 			return ctrl.Result{}, nil
@@ -119,7 +121,8 @@ func (r *AxonOpsKafkaTopicReconciler) Reconcile(ctx context.Context, req ctrl.Re
 			if err := apiClient.UpdateKafkaTopicConfig(ctx, topic.Spec.ClusterName, topic.Spec.Name, configs); err != nil {
 				log.Error(err, "Failed to update Kafka topic config")
 				r.setFailedCondition(ctx, topic, "UpdateFailed", fmt.Sprintf("Failed to update topic config: %v", err))
-				if apiErr, ok := err.(*axonops.APIError); ok && apiErr.IsRetryable() {
+				var apiErr *axonops.APIError
+				if errors.As(err, &apiErr) && apiErr.IsRetryable() {
 					return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 				}
 				return ctrl.Result{}, nil
@@ -173,7 +176,8 @@ func (r *AxonOpsKafkaTopicReconciler) handleDeletion(ctx context.Context, topic 
 	if topic.Status.Synced {
 		if err := apiClient.DeleteKafkaTopic(ctx, topic.Spec.ClusterName, topic.Spec.Name); err != nil {
 			log.Error(err, "Failed to delete Kafka topic")
-			if apiErr, ok := err.(*axonops.APIError); ok && apiErr.IsRetryable() {
+			var apiErr *axonops.APIError
+			if errors.As(err, &apiErr) && apiErr.IsRetryable() {
 				return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 			}
 		} else {


### PR DESCRIPTION
## Summary

Addresses findings #73 (B3) and #75 (I7) from the comprehensive code review.

### Changes

1. **Replace 32 bare `err.(*axonops.APIError)` type assertions** with `errors.As(err, &apiErr)` across all 11 controller files. This prevents silent retry failures if errors are ever wrapped with `fmt.Errorf("%w", ...)` — the bare assertion would return `ok=false`, treating retryable 5xx errors as permanent.

2. **Remove custom O(n²) `sortStrings` bubble sort** in backup controller. Replaced with stdlib `slices.Sort`.

### Verification

```bash
# Zero bare type assertions remain:
grep -rn 'err.(*axonops.APIError)' internal/controller/ | wc -l
# 0

# 32 errors.As usages:
grep -rn 'errors.As(err, &apiErr)' internal/controller/ | wc -l
# 32
```

## Test plan
- [x] `make fmt && make vet && make lint` — 0 issues
- [x] `make test` — all tests pass

Ref #73, #75