### PR TITLE
chore: sync Helm chart RBAC with generated manifests for all new CRDs

### DIFF
--- a/charts/axonops-operator/templates/rbac/alerts-axonopsadaptiverepair-admin-role.yaml
+++ b/charts/axonops-operator/templates/rbac/alerts-axonopsadaptiverepair-admin-role.yaml
@@ -1,0 +1,27 @@
+# This rule is not used by the project axonops-operator itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants full permissions ('*') over alerts.axonops.com.
+# This role is intended for users authorized to modify roles and bindings within the cluster,
+# enabling them to delegate specific permissions to other users or groups as needed.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: axonops-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: alerts-axonopsadaptiverepair-admin-role
+rules:
+- apiGroups:
+  - alerts.axonops.com
+  resources:
+  - axonopsadaptiverepairs
+  verbs:
+  - '*'
+- apiGroups:
+  - alerts.axonops.com
+  resources:
+  - axonopsadaptiverepairs/status
+  verbs:
+  - get

--- a/charts/axonops-operator/templates/rbac/alerts-axonopsadaptiverepair-editor-role.yaml
+++ b/charts/axonops-operator/templates/rbac/alerts-axonopsadaptiverepair-editor-role.yaml
@@ -1,0 +1,33 @@
+# This rule is not used by the project axonops-operator itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants permissions to create, update, and delete resources within the alerts.axonops.com.
+# This role is intended for users who need to manage these resources
+# but should not control RBAC or manage permissions for others.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: axonops-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: alerts-axonopsadaptiverepair-editor-role
+rules:
+- apiGroups:
+  - alerts.axonops.com
+  resources:
+  - axonopsadaptiverepairs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - alerts.axonops.com
+  resources:
+  - axonopsadaptiverepairs/status
+  verbs:
+  - get

--- a/charts/axonops-operator/templates/rbac/alerts-axonopsadaptiverepair-viewer-role.yaml
+++ b/charts/axonops-operator/templates/rbac/alerts-axonopsadaptiverepair-viewer-role.yaml
@@ -1,0 +1,29 @@
+# This rule is not used by the project axonops-operator itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants read-only access to alerts.axonops.com resources.
+# This role is intended for users who need visibility into these resources
+# without permissions to modify them. It is ideal for monitoring purposes and limited-access viewing.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: axonops-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: alerts-axonopsadaptiverepair-viewer-role
+rules:
+- apiGroups:
+  - alerts.axonops.com
+  resources:
+  - axonopsadaptiverepairs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - alerts.axonops.com
+  resources:
+  - axonopsadaptiverepairs/status
+  verbs:
+  - get

--- a/charts/axonops-operator/templates/rbac/alerts-axonopsalertendpoint-admin-role.yaml
+++ b/charts/axonops-operator/templates/rbac/alerts-axonopsalertendpoint-admin-role.yaml
@@ -1,0 +1,27 @@
+# This rule is not used by the project axonops-operator itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants full permissions ('*') over alerts.axonops.com.
+# This role is intended for users authorized to modify roles and bindings within the cluster,
+# enabling them to delegate specific permissions to other users or groups as needed.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: axonops-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: alerts-axonopsalertendpoint-admin-role
+rules:
+- apiGroups:
+  - alerts.axonops.com
+  resources:
+  - axonopsalertendpoints
+  verbs:
+  - '*'
+- apiGroups:
+  - alerts.axonops.com
+  resources:
+  - axonopsalertendpoints/status
+  verbs:
+  - get

--- a/charts/axonops-operator/templates/rbac/alerts-axonopsalertendpoint-editor-role.yaml
+++ b/charts/axonops-operator/templates/rbac/alerts-axonopsalertendpoint-editor-role.yaml
@@ -1,0 +1,33 @@
+# This rule is not used by the project axonops-operator itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants permissions to create, update, and delete resources within the alerts.axonops.com.
+# This role is intended for users who need to manage these resources
+# but should not control RBAC or manage permissions for others.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: axonops-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: alerts-axonopsalertendpoint-editor-role
+rules:
+- apiGroups:
+  - alerts.axonops.com
+  resources:
+  - axonopsalertendpoints
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - alerts.axonops.com
+  resources:
+  - axonopsalertendpoints/status
+  verbs:
+  - get

--- a/charts/axonops-operator/templates/rbac/alerts-axonopsalertendpoint-viewer-role.yaml
+++ b/charts/axonops-operator/templates/rbac/alerts-axonopsalertendpoint-viewer-role.yaml
@@ -1,0 +1,29 @@
+# This rule is not used by the project axonops-operator itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants read-only access to alerts.axonops.com resources.
+# This role is intended for users who need visibility into these resources
+# without permissions to modify them. It is ideal for monitoring purposes and limited-access viewing.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: axonops-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: alerts-axonopsalertendpoint-viewer-role
+rules:
+- apiGroups:
+  - alerts.axonops.com
+  resources:
+  - axonopsalertendpoints
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - alerts.axonops.com
+  resources:
+  - axonopsalertendpoints/status
+  verbs:
+  - get

--- a/charts/axonops-operator/templates/rbac/alerts-axonopscommitlogarchive-admin-role.yaml
+++ b/charts/axonops-operator/templates/rbac/alerts-axonopscommitlogarchive-admin-role.yaml
@@ -1,0 +1,27 @@
+# This rule is not used by the project axonops-operator itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants full permissions ('*') over alerts.axonops.com.
+# This role is intended for users authorized to modify roles and bindings within the cluster,
+# enabling them to delegate specific permissions to other users or groups as needed.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: axonops-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: alerts-axonopscommitlogarchive-admin-role
+rules:
+- apiGroups:
+  - alerts.axonops.com
+  resources:
+  - axonopscommitlogarchives
+  verbs:
+  - '*'
+- apiGroups:
+  - alerts.axonops.com
+  resources:
+  - axonopscommitlogarchives/status
+  verbs:
+  - get

--- a/charts/axonops-operator/templates/rbac/alerts-axonopscommitlogarchive-editor-role.yaml
+++ b/charts/axonops-operator/templates/rbac/alerts-axonopscommitlogarchive-editor-role.yaml
@@ -1,0 +1,33 @@
+# This rule is not used by the project axonops-operator itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants permissions to create, update, and delete resources within the alerts.axonops.com.
+# This role is intended for users who need to manage these resources
+# but should not control RBAC or manage permissions for others.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: axonops-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: alerts-axonopscommitlogarchive-editor-role
+rules:
+- apiGroups:
+  - alerts.axonops.com
+  resources:
+  - axonopscommitlogarchives
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - alerts.axonops.com
+  resources:
+  - axonopscommitlogarchives/status
+  verbs:
+  - get

--- a/charts/axonops-operator/templates/rbac/alerts-axonopscommitlogarchive-viewer-role.yaml
+++ b/charts/axonops-operator/templates/rbac/alerts-axonopscommitlogarchive-viewer-role.yaml
@@ -1,0 +1,29 @@
+# This rule is not used by the project axonops-operator itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants read-only access to alerts.axonops.com resources.
+# This role is intended for users who need visibility into these resources
+# without permissions to modify them. It is ideal for monitoring purposes and limited-access viewing.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: axonops-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: alerts-axonopscommitlogarchive-viewer-role
+rules:
+- apiGroups:
+  - alerts.axonops.com
+  resources:
+  - axonopscommitlogarchives
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - alerts.axonops.com
+  resources:
+  - axonopscommitlogarchives/status
+  verbs:
+  - get

--- a/charts/axonops-operator/templates/rbac/alerts-axonopsdashboardtemplate-admin-role.yaml
+++ b/charts/axonops-operator/templates/rbac/alerts-axonopsdashboardtemplate-admin-role.yaml
@@ -1,0 +1,27 @@
+# This rule is not used by the project axonops-operator itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants full permissions ('*') over alerts.axonops.com.
+# This role is intended for users authorized to modify roles and bindings within the cluster,
+# enabling them to delegate specific permissions to other users or groups as needed.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: axonops-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: alerts-axonopsdashboardtemplate-admin-role
+rules:
+- apiGroups:
+  - alerts.axonops.com
+  resources:
+  - axonopsdashboardtemplates
+  verbs:
+  - '*'
+- apiGroups:
+  - alerts.axonops.com
+  resources:
+  - axonopsdashboardtemplates/status
+  verbs:
+  - get

--- a/charts/axonops-operator/templates/rbac/alerts-axonopsdashboardtemplate-editor-role.yaml
+++ b/charts/axonops-operator/templates/rbac/alerts-axonopsdashboardtemplate-editor-role.yaml
@@ -1,0 +1,33 @@
+# This rule is not used by the project axonops-operator itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants permissions to create, update, and delete resources within the alerts.axonops.com.
+# This role is intended for users who need to manage these resources
+# but should not control RBAC or manage permissions for others.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: axonops-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: alerts-axonopsdashboardtemplate-editor-role
+rules:
+- apiGroups:
+  - alerts.axonops.com
+  resources:
+  - axonopsdashboardtemplates
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - alerts.axonops.com
+  resources:
+  - axonopsdashboardtemplates/status
+  verbs:
+  - get

--- a/charts/axonops-operator/templates/rbac/alerts-axonopsdashboardtemplate-viewer-role.yaml
+++ b/charts/axonops-operator/templates/rbac/alerts-axonopsdashboardtemplate-viewer-role.yaml
@@ -1,0 +1,29 @@
+# This rule is not used by the project axonops-operator itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants read-only access to alerts.axonops.com resources.
+# This role is intended for users who need visibility into these resources
+# without permissions to modify them. It is ideal for monitoring purposes and limited-access viewing.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: axonops-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: alerts-axonopsdashboardtemplate-viewer-role
+rules:
+- apiGroups:
+  - alerts.axonops.com
+  resources:
+  - axonopsdashboardtemplates
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - alerts.axonops.com
+  resources:
+  - axonopsdashboardtemplates/status
+  verbs:
+  - get

--- a/charts/axonops-operator/templates/rbac/alerts-axonopsscheduledrepair-admin-role.yaml
+++ b/charts/axonops-operator/templates/rbac/alerts-axonopsscheduledrepair-admin-role.yaml
@@ -1,0 +1,27 @@
+# This rule is not used by the project axonops-operator itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants full permissions ('*') over alerts.axonops.com.
+# This role is intended for users authorized to modify roles and bindings within the cluster,
+# enabling them to delegate specific permissions to other users or groups as needed.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: axonops-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: alerts-axonopsscheduledrepair-admin-role
+rules:
+- apiGroups:
+  - alerts.axonops.com
+  resources:
+  - axonopsscheduledrepairs
+  verbs:
+  - '*'
+- apiGroups:
+  - alerts.axonops.com
+  resources:
+  - axonopsscheduledrepairs/status
+  verbs:
+  - get

--- a/charts/axonops-operator/templates/rbac/alerts-axonopsscheduledrepair-editor-role.yaml
+++ b/charts/axonops-operator/templates/rbac/alerts-axonopsscheduledrepair-editor-role.yaml
@@ -1,0 +1,33 @@
+# This rule is not used by the project axonops-operator itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants permissions to create, update, and delete resources within the alerts.axonops.com.
+# This role is intended for users who need to manage these resources
+# but should not control RBAC or manage permissions for others.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: axonops-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: alerts-axonopsscheduledrepair-editor-role
+rules:
+- apiGroups:
+  - alerts.axonops.com
+  resources:
+  - axonopsscheduledrepairs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - alerts.axonops.com
+  resources:
+  - axonopsscheduledrepairs/status
+  verbs:
+  - get

--- a/charts/axonops-operator/templates/rbac/alerts-axonopsscheduledrepair-viewer-role.yaml
+++ b/charts/axonops-operator/templates/rbac/alerts-axonopsscheduledrepair-viewer-role.yaml
@@ -1,0 +1,29 @@
+# This rule is not used by the project axonops-operator itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants read-only access to alerts.axonops.com resources.
+# This role is intended for users who need visibility into these resources
+# without permissions to modify them. It is ideal for monitoring purposes and limited-access viewing.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: axonops-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: alerts-axonopsscheduledrepair-viewer-role
+rules:
+- apiGroups:
+  - alerts.axonops.com
+  resources:
+  - axonopsscheduledrepairs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - alerts.axonops.com
+  resources:
+  - axonopsscheduledrepairs/status
+  verbs:
+  - get

--- a/charts/axonops-operator/templates/rbac/backups-axonopsbackup-admin-role.yaml
+++ b/charts/axonops-operator/templates/rbac/backups-axonopsbackup-admin-role.yaml
@@ -1,0 +1,27 @@
+# This rule is not used by the project axonops-operator itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants full permissions ('*') over backups.axonops.com.
+# This role is intended for users authorized to modify roles and bindings within the cluster,
+# enabling them to delegate specific permissions to other users or groups as needed.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: axonops-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: backups-axonopsbackup-admin-role
+rules:
+- apiGroups:
+  - backups.axonops.com
+  resources:
+  - axonopsbackups
+  verbs:
+  - '*'
+- apiGroups:
+  - backups.axonops.com
+  resources:
+  - axonopsbackups/status
+  verbs:
+  - get

--- a/charts/axonops-operator/templates/rbac/backups-axonopsbackup-editor-role.yaml
+++ b/charts/axonops-operator/templates/rbac/backups-axonopsbackup-editor-role.yaml
@@ -1,0 +1,33 @@
+# This rule is not used by the project axonops-operator itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants permissions to create, update, and delete resources within the backups.axonops.com.
+# This role is intended for users who need to manage these resources
+# but should not control RBAC or manage permissions for others.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: axonops-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: backups-axonopsbackup-editor-role
+rules:
+- apiGroups:
+  - backups.axonops.com
+  resources:
+  - axonopsbackups
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - backups.axonops.com
+  resources:
+  - axonopsbackups/status
+  verbs:
+  - get

--- a/charts/axonops-operator/templates/rbac/backups-axonopsbackup-viewer-role.yaml
+++ b/charts/axonops-operator/templates/rbac/backups-axonopsbackup-viewer-role.yaml
@@ -1,0 +1,29 @@
+# This rule is not used by the project axonops-operator itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants read-only access to backups.axonops.com resources.
+# This role is intended for users who need visibility into these resources
+# without permissions to modify them. It is ideal for monitoring purposes and limited-access viewing.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: axonops-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: backups-axonopsbackup-viewer-role
+rules:
+- apiGroups:
+  - backups.axonops.com
+  resources:
+  - axonopsbackups
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - backups.axonops.com
+  resources:
+  - axonopsbackups/status
+  verbs:
+  - get

--- a/charts/axonops-operator/templates/rbac/kafka-axonopskafkaacl-admin-role.yaml
+++ b/charts/axonops-operator/templates/rbac/kafka-axonopskafkaacl-admin-role.yaml
@@ -1,0 +1,27 @@
+# This rule is not used by the project axonops-operator itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants full permissions ('*') over kafka.axonops.com.
+# This role is intended for users authorized to modify roles and bindings within the cluster,
+# enabling them to delegate specific permissions to other users or groups as needed.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: axonops-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: kafka-axonopskafkaacl-admin-role
+rules:
+- apiGroups:
+  - kafka.axonops.com
+  resources:
+  - axonopskafkaacls
+  verbs:
+  - '*'
+- apiGroups:
+  - kafka.axonops.com
+  resources:
+  - axonopskafkaacls/status
+  verbs:
+  - get

--- a/charts/axonops-operator/templates/rbac/kafka-axonopskafkaacl-editor-role.yaml
+++ b/charts/axonops-operator/templates/rbac/kafka-axonopskafkaacl-editor-role.yaml
@@ -1,0 +1,33 @@
+# This rule is not used by the project axonops-operator itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants permissions to create, update, and delete resources within the kafka.axonops.com.
+# This role is intended for users who need to manage these resources
+# but should not control RBAC or manage permissions for others.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: axonops-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: kafka-axonopskafkaacl-editor-role
+rules:
+- apiGroups:
+  - kafka.axonops.com
+  resources:
+  - axonopskafkaacls
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kafka.axonops.com
+  resources:
+  - axonopskafkaacls/status
+  verbs:
+  - get

--- a/charts/axonops-operator/templates/rbac/kafka-axonopskafkaacl-viewer-role.yaml
+++ b/charts/axonops-operator/templates/rbac/kafka-axonopskafkaacl-viewer-role.yaml
@@ -1,0 +1,29 @@
+# This rule is not used by the project axonops-operator itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants read-only access to kafka.axonops.com resources.
+# This role is intended for users who need visibility into these resources
+# without permissions to modify them. It is ideal for monitoring purposes and limited-access viewing.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: axonops-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: kafka-axonopskafkaacl-viewer-role
+rules:
+- apiGroups:
+  - kafka.axonops.com
+  resources:
+  - axonopskafkaacls
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - kafka.axonops.com
+  resources:
+  - axonopskafkaacls/status
+  verbs:
+  - get

--- a/charts/axonops-operator/templates/rbac/kafka-axonopskafkaconnector-admin-role.yaml
+++ b/charts/axonops-operator/templates/rbac/kafka-axonopskafkaconnector-admin-role.yaml
@@ -1,0 +1,27 @@
+# This rule is not used by the project axonops-operator itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants full permissions ('*') over kafka.axonops.com.
+# This role is intended for users authorized to modify roles and bindings within the cluster,
+# enabling them to delegate specific permissions to other users or groups as needed.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: axonops-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: kafka-axonopskafkaconnector-admin-role
+rules:
+- apiGroups:
+  - kafka.axonops.com
+  resources:
+  - axonopskafkaconnectors
+  verbs:
+  - '*'
+- apiGroups:
+  - kafka.axonops.com
+  resources:
+  - axonopskafkaconnectors/status
+  verbs:
+  - get

--- a/charts/axonops-operator/templates/rbac/kafka-axonopskafkaconnector-editor-role.yaml
+++ b/charts/axonops-operator/templates/rbac/kafka-axonopskafkaconnector-editor-role.yaml
@@ -1,0 +1,33 @@
+# This rule is not used by the project axonops-operator itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants permissions to create, update, and delete resources within the kafka.axonops.com.
+# This role is intended for users who need to manage these resources
+# but should not control RBAC or manage permissions for others.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: axonops-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: kafka-axonopskafkaconnector-editor-role
+rules:
+- apiGroups:
+  - kafka.axonops.com
+  resources:
+  - axonopskafkaconnectors
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kafka.axonops.com
+  resources:
+  - axonopskafkaconnectors/status
+  verbs:
+  - get

--- a/charts/axonops-operator/templates/rbac/kafka-axonopskafkaconnector-viewer-role.yaml
+++ b/charts/axonops-operator/templates/rbac/kafka-axonopskafkaconnector-viewer-role.yaml
@@ -1,0 +1,29 @@
+# This rule is not used by the project axonops-operator itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants read-only access to kafka.axonops.com resources.
+# This role is intended for users who need visibility into these resources
+# without permissions to modify them. It is ideal for monitoring purposes and limited-access viewing.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: axonops-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: kafka-axonopskafkaconnector-viewer-role
+rules:
+- apiGroups:
+  - kafka.axonops.com
+  resources:
+  - axonopskafkaconnectors
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - kafka.axonops.com
+  resources:
+  - axonopskafkaconnectors/status
+  verbs:
+  - get

--- a/charts/axonops-operator/templates/rbac/kafka-axonopskafkatopic-admin-role.yaml
+++ b/charts/axonops-operator/templates/rbac/kafka-axonopskafkatopic-admin-role.yaml
@@ -1,0 +1,27 @@
+# This rule is not used by the project axonops-operator itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants full permissions ('*') over kafka.axonops.com.
+# This role is intended for users authorized to modify roles and bindings within the cluster,
+# enabling them to delegate specific permissions to other users or groups as needed.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: axonops-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: kafka-axonopskafkatopic-admin-role
+rules:
+- apiGroups:
+  - kafka.axonops.com
+  resources:
+  - axonopskafkatopics
+  verbs:
+  - '*'
+- apiGroups:
+  - kafka.axonops.com
+  resources:
+  - axonopskafkatopics/status
+  verbs:
+  - get

--- a/charts/axonops-operator/templates/rbac/kafka-axonopskafkatopic-editor-role.yaml
+++ b/charts/axonops-operator/templates/rbac/kafka-axonopskafkatopic-editor-role.yaml
@@ -1,0 +1,33 @@
+# This rule is not used by the project axonops-operator itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants permissions to create, update, and delete resources within the kafka.axonops.com.
+# This role is intended for users who need to manage these resources
+# but should not control RBAC or manage permissions for others.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: axonops-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: kafka-axonopskafkatopic-editor-role
+rules:
+- apiGroups:
+  - kafka.axonops.com
+  resources:
+  - axonopskafkatopics
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kafka.axonops.com
+  resources:
+  - axonopskafkatopics/status
+  verbs:
+  - get

--- a/charts/axonops-operator/templates/rbac/kafka-axonopskafkatopic-viewer-role.yaml
+++ b/charts/axonops-operator/templates/rbac/kafka-axonopskafkatopic-viewer-role.yaml
@@ -1,0 +1,29 @@
+# This rule is not used by the project axonops-operator itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants read-only access to kafka.axonops.com resources.
+# This role is intended for users who need visibility into these resources
+# without permissions to modify them. It is ideal for monitoring purposes and limited-access viewing.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: axonops-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: kafka-axonopskafkatopic-viewer-role
+rules:
+- apiGroups:
+  - kafka.axonops.com
+  resources:
+  - axonopskafkatopics
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - kafka.axonops.com
+  resources:
+  - axonopskafkatopics/status
+  verbs:
+  - get

--- a/charts/axonops-operator/templates/rbac/metrics-reader-role.yaml
+++ b/charts/axonops-operator/templates/rbac/metrics-reader-role.yaml
@@ -1,0 +1,9 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: metrics-reader
+rules:
+- nonResourceURLs:
+  - "/metrics"
+  verbs:
+  - get


### PR DESCRIPTION
## Summary

The Helm chart at `charts/axonops-operator/` was missing 28 RBAC role files for CRDs added since the chart was last updated. This syncs them from the kubebuilder-generated `config/rbac/` directory.

### What was out of sync

| Group | Missing RBAC for | Files Added |
|---|---|---|
| `alerts.axonops.com` | AdaptiveRepair, AlertEndpoint, CommitlogArchive, DashboardTemplate, ScheduledRepair | 15 |
| `backups.axonops.com` | AxonOpsBackup | 3 |
| `kafka.axonops.com` | KafkaTopic, KafkaACL, KafkaConnector | 9 |
| metrics | metrics-reader | 1 |

### What was already in sync
- All 17 CRDs — no changes needed
- Manager ClusterRole rules
- Leader election role rules

## Test plan
- [x] All RBAC source files present in Helm chart
- [x] Manager role rules match between source and Helm template
- [x] CRDs match between source and Helm chart