### PR TITLE
feat(axonops-export): export all resource types (log alerts, healthchecks, integrations, repairs, backups, silences)

### DIFF
--- a/cmd/axonops-export/export/connection.go
+++ b/cmd/axonops-export/export/connection.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026.
+© 2026 AxonOps Limited. All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/axonops-export/export/healthcheck.go
+++ b/cmd/axonops-export/export/healthcheck.go
@@ -1,0 +1,178 @@
+/*
+© 2026 AxonOps Limited. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package export
+
+import (
+	"context"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	alertsv1alpha1 "github.com/axonops/axonops-operator/api/alerts/v1alpha1"
+	"github.com/axonops/axonops-operator/internal/axonops"
+)
+
+// exportHealthchecks fetches all healthcheck types and returns CRD resources.
+func exportHealthchecks(ctx context.Context, client *axonops.Client, opts *Options) ([]Resource, error) {
+	hc, err := client.GetHealthchecks(ctx, opts.ClusterType, opts.ClusterName)
+	if err != nil {
+		return nil, fmt.Errorf("fetching healthchecks: %w", err)
+	}
+
+	var resources []Resource
+
+	for _, h := range hc.HTTPChecks {
+		r := httpHealthcheckToResource(h, opts)
+		resources = append(resources, r)
+	}
+	for _, t := range hc.TCPChecks {
+		r := tcpHealthcheckToResource(t, opts)
+		resources = append(resources, r)
+	}
+	for _, s := range hc.ShellChecks {
+		r := shellHealthcheckToResource(s, opts)
+		resources = append(resources, r)
+	}
+
+	return resources, nil
+}
+
+func httpHealthcheckToResource(h axonops.HealthcheckHTTP, opts *Options) Resource {
+	name := toDNSLabel(h.Name)
+
+	// Parse headers from "Key: Value" strings to map
+	headers := make(map[string]string)
+	for _, hdr := range h.Headers {
+		if i := indexByte(hdr, ':'); i >= 0 {
+			headers[trimSpace(hdr[:i])] = trimSpace(hdr[i+1:])
+		}
+	}
+
+	obj := &alertsv1alpha1.AxonOpsHealthcheckHTTP{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "alerts.axonops.com/v1alpha1",
+			Kind:       "AxonOpsHealthcheckHTTP",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: opts.Namespace,
+		},
+		Spec: alertsv1alpha1.AxonOpsHealthcheckHTTPSpec{
+			ConnectionRef:       opts.ConnectionName,
+			ClusterName:         opts.ClusterName,
+			ClusterType:         opts.ClusterType,
+			Name:                h.Name,
+			URL:                 h.HTTP,
+			Method:              h.Method,
+			Body:                h.Body,
+			ExpectedStatus:      h.ExpectedStatus,
+			Interval:            h.Interval,
+			Timeout:             h.Timeout,
+			Readonly:            h.Readonly,
+			TLSSkipVerify:       h.TLSSkipVerify,
+			SupportedAgentTypes: h.SupportedAgentTypes,
+		},
+	}
+	if len(headers) > 0 {
+		obj.Spec.Headers = headers
+	}
+
+	return Resource{Kind: "AxonOpsHealthcheckHTTP", Name: name, Object: obj}
+}
+
+func tcpHealthcheckToResource(t axonops.HealthcheckTCP, opts *Options) Resource {
+	name := toDNSLabel(t.Name)
+
+	return Resource{
+		Kind: "AxonOpsHealthcheckTCP",
+		Name: name,
+		Object: &alertsv1alpha1.AxonOpsHealthcheckTCP{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "alerts.axonops.com/v1alpha1",
+				Kind:       "AxonOpsHealthcheckTCP",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: opts.Namespace,
+			},
+			Spec: alertsv1alpha1.AxonOpsHealthcheckTCPSpec{
+				ConnectionRef:       opts.ConnectionName,
+				ClusterName:         opts.ClusterName,
+				ClusterType:         opts.ClusterType,
+				Name:                t.Name,
+				TCP:                 t.TCP,
+				Interval:            t.Interval,
+				Timeout:             t.Timeout,
+				Readonly:            t.Readonly,
+				SupportedAgentTypes: t.SupportedAgentTypes,
+			},
+		},
+	}
+}
+
+func shellHealthcheckToResource(s axonops.HealthcheckShell, opts *Options) Resource {
+	name := toDNSLabel(s.Name)
+
+	return Resource{
+		Kind: "AxonOpsHealthcheckShell",
+		Name: name,
+		Object: &alertsv1alpha1.AxonOpsHealthcheckShell{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "alerts.axonops.com/v1alpha1",
+				Kind:       "AxonOpsHealthcheckShell",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: opts.Namespace,
+			},
+			Spec: alertsv1alpha1.AxonOpsHealthcheckShellSpec{
+				ConnectionRef: opts.ConnectionName,
+				ClusterName:   opts.ClusterName,
+				ClusterType:   opts.ClusterType,
+				Name:          s.Name,
+				Script:        s.Script,
+				Shell:         s.Shell,
+				Interval:      s.Interval,
+				Timeout:       s.Timeout,
+				Readonly:      s.Readonly,
+			},
+		},
+	}
+}
+
+// indexByte returns the index of b in s, or -1.
+func indexByte(s string, b byte) int {
+	for i := 0; i < len(s); i++ {
+		if s[i] == b {
+			return i
+		}
+	}
+	return -1
+}
+
+// trimSpace trims ASCII whitespace from both ends.
+func trimSpace(s string) string {
+	start := 0
+	for start < len(s) && (s[start] == ' ' || s[start] == '\t') {
+		start++
+	}
+	end := len(s)
+	for end > start && (s[end-1] == ' ' || s[end-1] == '\t') {
+		end--
+	}
+	return s[start:end]
+}

--- a/cmd/axonops-export/export/integration.go
+++ b/cmd/axonops-export/export/integration.go
@@ -1,0 +1,221 @@
+/*
+© 2026 AxonOps Limited. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package export
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	alertsv1alpha1 "github.com/axonops/axonops-operator/api/alerts/v1alpha1"
+	"github.com/axonops/axonops-operator/internal/axonops"
+)
+
+const (
+	intTypeMicrosoftTeams = "microsoft_teams"
+	intTypePagerDuty      = "pagerduty"
+)
+
+// exportIntegrations fetches integration definitions and routing and converts them
+// to AxonOpsAlertEndpoint and AxonOpsAlertRoute CRD resources.
+func exportIntegrations(ctx context.Context, client *axonops.Client, opts *Options) ([]Resource, error) {
+	integrations, err := client.GetIntegrations(ctx, opts.ClusterType, opts.ClusterName)
+	if err != nil {
+		return nil, fmt.Errorf("fetching integrations: %w", err)
+	}
+
+	// Build lookup maps for route generation: ID → name and ID → type
+	idToName := make(map[string]string, len(integrations.Definitions))
+	idToType := make(map[string]string, len(integrations.Definitions))
+
+	var resources []Resource
+
+	// Export endpoint definitions
+	for _, def := range integrations.Definitions {
+		r := integrationDefToResource(def, opts)
+		resources = append(resources, r)
+		name := def.Params["name"]
+		if name == "" {
+			name = def.ID
+		}
+		idToName[def.ID] = name
+		idToType[def.ID] = strings.ToLower(def.Type)
+	}
+
+	// Export routing rules
+	for _, routing := range integrations.Routings {
+		for _, route := range routing.Routing {
+			r := integrationRouteToResource(routing, route, idToName, idToType, opts)
+			if r != nil {
+				resources = append(resources, *r)
+			}
+		}
+	}
+
+	return resources, nil
+}
+
+// integrationDefToResource converts an IntegrationDefinition to an AxonOpsAlertEndpoint resource.
+func integrationDefToResource(def axonops.IntegrationDefinition, opts *Options) Resource {
+	// Normalise the type to match CRD enum values
+	intType := strings.ToLower(def.Type)
+	// The API returns types like "Slack", "PagerDuty", "MicrosoftTeams" — normalise
+	switch intType {
+	case "microsoftteams":
+		intType = intTypeMicrosoftTeams
+	case intTypePagerDuty:
+		// already correct
+	}
+
+	endpointName := def.Params["name"]
+	if endpointName == "" {
+		endpointName = def.ID
+	}
+	name := toDNSLabel(endpointName)
+
+	obj := &alertsv1alpha1.AxonOpsAlertEndpoint{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "alerts.axonops.com/v1alpha1",
+			Kind:       "AxonOpsAlertEndpoint",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: opts.Namespace,
+		},
+		Spec: alertsv1alpha1.AxonOpsAlertEndpointSpec{
+			ConnectionRef: opts.ConnectionName,
+			ClusterName:   opts.ClusterName,
+			ClusterType:   opts.ClusterType,
+			Name:          endpointName,
+			Type:          intType,
+		},
+	}
+
+	// Set type-specific config with placeholder credentials
+	switch intType {
+	case "slack":
+		obj.Spec.Slack = &alertsv1alpha1.SlackEndpointConfig{
+			URL:         "<REPLACE_WITH_WEBHOOK_URL>",
+			Channel:     def.Params["channel"],
+			AxonDashURL: def.Params["axondash_url"],
+		}
+	case intTypePagerDuty:
+		obj.Spec.PagerDuty = &alertsv1alpha1.PagerDutyEndpointConfig{
+			IntegrationKey: "<REPLACE_WITH_INTEGRATION_KEY>",
+		}
+	case "opsgenie":
+		obj.Spec.OpsGenie = &alertsv1alpha1.OpsGenieEndpointConfig{
+			OpsGenieKey: "<REPLACE_WITH_OPSGENIE_KEY>",
+		}
+	case "servicenow":
+		obj.Spec.ServiceNow = &alertsv1alpha1.ServiceNowEndpointConfig{
+			InstanceName: def.Params["instance"],
+			User:         def.Params["user"],
+			Password:     "<REPLACE_WITH_PASSWORD>",
+		}
+	case intTypeMicrosoftTeams:
+		obj.Spec.MicrosoftTeams = &alertsv1alpha1.MicrosoftTeamsEndpointConfig{
+			WebHookURL: "<REPLACE_WITH_WEBHOOK_URL>",
+		}
+	default:
+		// email, smtp, webhook — copy params directly (no secrets exposed)
+		params := make(map[string]string, len(def.Params))
+		maps.Copy(params, def.Params)
+		if len(params) > 0 {
+			obj.Spec.Params = params
+		}
+	}
+
+	return Resource{Kind: "AxonOpsAlertEndpoint", Name: name, Object: obj}
+}
+
+// integrationRouteToResource converts an integration routing entry to an AxonOpsAlertRoute.
+// Returns nil when the route type or severity is not representable in the CRD.
+func integrationRouteToResource(
+	routing axonops.IntegrationRouting,
+	route axonops.IntegrationRoute,
+	idToName map[string]string,
+	idToType map[string]string,
+	opts *Options,
+) *Resource {
+	routeType := strings.ToLower(routing.Type)
+	severity := strings.ToLower(route.Severity)
+
+	// Normalise route type to CRD enum values
+	switch routeType {
+	case "service checks":
+		routeType = "servicechecks"
+	case "rolling restart":
+		routeType = "rollingrestart"
+	}
+
+	validTypes := map[string]bool{
+		"global": true, "metrics": true, "backups": true, "servicechecks": true,
+		"nodes": true, "commands": true, "repairs": true, "rollingrestart": true,
+	}
+	validSeverities := map[string]bool{"info": true, "warning": true, "error": true}
+
+	if !validTypes[routeType] || !validSeverities[severity] {
+		return nil
+	}
+
+	integrationName := idToName[route.ID]
+	if integrationName == "" {
+		integrationName = route.ID
+	}
+
+	// Resolve the actual integration type (slack, pagerduty, etc.) from the definition map
+	integrationType := idToType[route.ID]
+	if integrationType == "" {
+		integrationType = "email" // safe fallback
+	}
+	// Normalise to CRD enum
+	switch integrationType {
+	case intTypeMicrosoftTeams, "microsoftteams":
+		integrationType = "teams"
+	}
+
+	name := toDNSLabel(fmt.Sprintf("%s-%s-%s", routeType, severity, integrationName))
+
+	enableOverride := true
+	obj := &alertsv1alpha1.AxonOpsAlertRoute{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "alerts.axonops.com/v1alpha1",
+			Kind:       "AxonOpsAlertRoute",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: opts.Namespace,
+		},
+		Spec: alertsv1alpha1.AxonOpsAlertRouteSpec{
+			ConnectionRef:   opts.ConnectionName,
+			ClusterName:     opts.ClusterName,
+			ClusterType:     opts.ClusterType,
+			IntegrationName: integrationName,
+			IntegrationType: integrationType,
+			Type:            routeType,
+			Severity:        severity,
+			EnableOverride:  &enableOverride,
+		},
+	}
+
+	r := Resource{Kind: "AxonOpsAlertRoute", Name: name, Object: obj}
+	return &r
+}

--- a/cmd/axonops-export/export/metric_alert.go
+++ b/cmd/axonops-export/export/metric_alert.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026.
+© 2026 AxonOps Limited. All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -36,14 +36,11 @@ type panelInfo struct {
 
 // exportMetricAlerts fetches metric alert rules from the AxonOps API and
 // converts them to AxonOpsMetricAlert CRD resources.
+// Log alert rules (expr starts with "events{") are excluded.
 func exportMetricAlerts(ctx context.Context, client *axonops.Client, opts *Options) ([]Resource, error) {
 	rules, err := client.GetMetricAlertRules(ctx, opts.ClusterType, opts.ClusterName)
 	if err != nil {
 		return nil, fmt.Errorf("fetching metric alert rules: %w", err)
-	}
-
-	if len(rules) == 0 {
-		return nil, nil
 	}
 
 	// Build a reverse lookup: correlationId → (dashboard, chart)
@@ -55,10 +52,152 @@ func exportMetricAlerts(ctx context.Context, client *axonops.Client, opts *Optio
 
 	var resources []Resource
 	for _, rule := range rules {
+		if isLogAlertExpr(rule.Expr) {
+			continue // log alerts handled separately
+		}
 		r := metricAlertRuleToResource(rule, opts, panelIndex)
 		resources = append(resources, r)
 	}
 	return resources, nil
+}
+
+// exportLogAlerts fetches alert rules whose expression matches the log events
+// format ("events{...}") and converts them to AxonOpsLogAlert CRD resources.
+func exportLogAlerts(ctx context.Context, client *axonops.Client, opts *Options) ([]Resource, error) {
+	rules, err := client.GetMetricAlertRules(ctx, opts.ClusterType, opts.ClusterName)
+	if err != nil {
+		return nil, fmt.Errorf("fetching log alert rules: %w", err)
+	}
+
+	var resources []Resource
+	for _, rule := range rules {
+		if !isLogAlertExpr(rule.Expr) {
+			continue
+		}
+		r := logAlertRuleToResource(rule, opts)
+		resources = append(resources, r)
+	}
+	return resources, nil
+}
+
+// isLogAlertExpr returns true when the expression belongs to a log alert.
+// Log alert expressions start with "events{".
+func isLogAlertExpr(expr string) bool {
+	return strings.HasPrefix(strings.TrimSpace(expr), "events{")
+}
+
+// logAlertRuleToResource converts a log-alert MetricAlertRule to an AxonOpsLogAlert resource.
+func logAlertRuleToResource(rule axonops.MetricAlertRule, opts *Options) Resource {
+	name := toDNSLabel(rule.Alert)
+
+	alert := &alertsv1alpha1.AxonOpsLogAlert{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "alerts.axonops.com/v1alpha1",
+			Kind:       "AxonOpsLogAlert",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: opts.Namespace,
+		},
+		Spec: alertsv1alpha1.AxonOpsLogAlertSpec{
+			ConnectionRef: opts.ConnectionName,
+			ClusterName:   opts.ClusterName,
+			ClusterType:   opts.ClusterType,
+			Name:          rule.Alert,
+			Operator:      rule.Operator,
+			WarningValue:  rule.WarningValue,
+			CriticalValue: rule.CriticalValue,
+			Duration:      rule.For,
+		},
+	}
+
+	// Parse expr "events{message="x",level="y",source="z",type="t"}"
+	content, level, source, logType := parseLogEventsExpr(rule.Expr)
+	alert.Spec.Content = content
+	alert.Spec.Level = level
+	alert.Spec.Source = source
+	alert.Spec.LogType = logType
+
+	if rule.Annotations.Summary != "" || rule.Annotations.Description != "" {
+		alert.Spec.Annotations = &alertsv1alpha1.LogAlertAnnotations{
+			Summary:     rule.Annotations.Summary,
+			Description: rule.Annotations.Description,
+		}
+	}
+
+	// Filters
+	if len(rule.Filters) > 0 {
+		f := &alertsv1alpha1.LogAlertFilters{}
+		for _, af := range rule.Filters {
+			switch af.Name {
+			case "dc":
+				f.DataCenter = af.Value
+			case "rack":
+				f.Rack = af.Value
+			case "host_id":
+				f.HostID = af.Value
+			}
+		}
+		alert.Spec.Filters = f
+	}
+
+	return Resource{Kind: "AxonOpsLogAlert", Name: name, Object: alert}
+}
+
+// parseLogEventsExpr parses content, level, source, logType from an events expression.
+// Format: events{message="x",level="y",source="z",type="t"}
+func parseLogEventsExpr(expr string) (content, level, source, logType string) {
+	// Strip outer "events{...}"
+	inner := expr
+	if i := strings.Index(inner, "{"); i >= 0 {
+		inner = inner[i+1:]
+	}
+	if i := strings.LastIndex(inner, "}"); i >= 0 {
+		inner = inner[:i]
+	}
+
+	// Simple key="value" parser (handles escaped quotes inside values)
+	for len(inner) > 0 {
+		eqIdx := strings.Index(inner, "=")
+		if eqIdx < 0 {
+			break
+		}
+		key := strings.TrimSpace(inner[:eqIdx])
+		rest := inner[eqIdx+1:]
+		if len(rest) == 0 || rest[0] != '"' {
+			break
+		}
+		rest = rest[1:] // skip opening quote
+		// Find closing unescaped quote
+		var valBuf strings.Builder
+		i := 0
+		for i < len(rest) {
+			if rest[i] == '\\' && i+1 < len(rest) {
+				valBuf.WriteByte(rest[i+1])
+				i += 2
+				continue
+			}
+			if rest[i] == '"' {
+				i++
+				break
+			}
+			valBuf.WriteByte(rest[i])
+			i++
+		}
+		val := valBuf.String()
+		switch key {
+		case "message":
+			content = val
+		case "level":
+			level = strings.ReplaceAll(val, "|", ",")
+		case "source":
+			source = strings.ReplaceAll(val, "|", ",")
+		case "type":
+			logType = strings.ReplaceAll(val, "|", ",")
+		}
+		inner = strings.TrimLeft(rest[i:], ",")
+	}
+	return content, level, source, logType
 }
 
 // buildPanelIndex fetches all dashboards and builds a map from panel UUID to dashboard+chart info.

--- a/cmd/axonops-export/export/metric_alert_test.go
+++ b/cmd/axonops-export/export/metric_alert_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026.
+© 2026 AxonOps Limited. All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/axonops-export/export/naming.go
+++ b/cmd/axonops-export/export/naming.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026.
+© 2026 AxonOps Limited. All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/axonops-export/export/naming_test.go
+++ b/cmd/axonops-export/export/naming_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026.
+© 2026 AxonOps Limited. All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/axonops-export/export/options.go
+++ b/cmd/axonops-export/export/options.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026.
+© 2026 AxonOps Limited. All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/axonops-export/export/repair.go
+++ b/cmd/axonops-export/export/repair.go
@@ -1,0 +1,236 @@
+/*
+© 2026 AxonOps Limited. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package export
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	alertsv1alpha1 "github.com/axonops/axonops-operator/api/alerts/v1alpha1"
+	"github.com/axonops/axonops-operator/internal/axonops"
+)
+
+// exportAdaptiveRepair fetches adaptive repair settings and returns one resource.
+func exportAdaptiveRepair(ctx context.Context, client *axonops.Client, opts *Options) ([]Resource, error) {
+	settings, err := client.GetAdaptiveRepair(ctx, opts.ClusterType, opts.ClusterName)
+	if err != nil {
+		return nil, fmt.Errorf("fetching adaptive repair: %w", err)
+	}
+	if settings == nil {
+		return nil, nil
+	}
+
+	name := toDNSLabel(opts.ClusterName + "-adaptive-repair")
+
+	active := settings.Active
+	gcGrace := settings.GcGraceThreshold
+	tableParallelism := settings.TableParallelism
+	filterTWCS := settings.FilterTWCSTables
+	segRetries := settings.SegmentRetries
+	segTargetSizeMB := settings.SegmentTargetSizeMB
+	maxSegPerTable := settings.MaxSegmentsPerTable
+
+	obj := &alertsv1alpha1.AxonOpsAdaptiveRepair{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "alerts.axonops.com/v1alpha1",
+			Kind:       "AxonOpsAdaptiveRepair",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: opts.Namespace,
+		},
+		Spec: alertsv1alpha1.AxonOpsAdaptiveRepairSpec{
+			ConnectionRef:       opts.ConnectionName,
+			ClusterName:         opts.ClusterName,
+			ClusterType:         opts.ClusterType,
+			Active:              &active,
+			GcGraceThreshold:    &gcGrace,
+			TableParallelism:    &tableParallelism,
+			ExcludedTables:      settings.BlacklistedTables,
+			FilterTWCSTables:    &filterTWCS,
+			SegmentRetries:      &segRetries,
+			SegmentTargetSizeMB: &segTargetSizeMB,
+			SegmentTimeout:      settings.SegmentTimeout,
+			MaxSegmentsPerTable: &maxSegPerTable,
+		},
+	}
+
+	return []Resource{{Kind: "AxonOpsAdaptiveRepair", Name: name, Object: obj}}, nil
+}
+
+// exportScheduledRepairs fetches scheduled repairs and returns CRD resources.
+func exportScheduledRepairs(ctx context.Context, client *axonops.Client, opts *Options) ([]Resource, error) {
+	resp, err := client.GetScheduledRepairs(ctx, opts.ClusterType, opts.ClusterName)
+	if err != nil {
+		return nil, fmt.Errorf("fetching scheduled repairs: %w", err)
+	}
+	if resp == nil || len(resp.Repairs) == 0 {
+		return nil, nil
+	}
+
+	var resources []Resource
+	for _, entry := range resp.Repairs {
+		if len(entry.Params) == 0 {
+			continue
+		}
+		p := entry.Params[0]
+		tag := p.Tag
+		if tag == "" {
+			tag = entry.ID
+		}
+		name := toDNSLabel(opts.ClusterName + "-" + tag)
+
+		obj := &alertsv1alpha1.AxonOpsScheduledRepair{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "alerts.axonops.com/v1alpha1",
+				Kind:       "AxonOpsScheduledRepair",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: opts.Namespace,
+			},
+			Spec: alertsv1alpha1.AxonOpsScheduledRepairSpec{
+				ConnectionRef:       opts.ConnectionName,
+				ClusterName:         opts.ClusterName,
+				ClusterType:         opts.ClusterType,
+				Tag:                 tag,
+				ScheduleExpression:  p.ScheduleExpr,
+				Keyspace:            p.Keyspace,
+				Tables:              p.Tables,
+				BlacklistedTables:   p.BlacklistedTables,
+				Nodes:               p.Nodes,
+				SpecificDataCenters: p.SpecificDataCenters,
+				Parallelism:         p.Parallelism,
+				Segmented:           p.Segmented,
+				SegmentsPerNode:     p.SegmentsPerNode,
+				Incremental:         p.Incremental,
+				JobThreads:          p.JobThreads,
+				PrimaryRange:        p.PrimaryRange,
+				OptimiseStreams:     p.OptimiseStreams,
+				SkipPaxos:           p.SkipPaxos,
+				PaxosOnly:           p.PaxosOnly,
+			},
+		}
+		resources = append(resources, Resource{Kind: "AxonOpsScheduledRepair", Name: name, Object: obj})
+	}
+	return resources, nil
+}
+
+// exportBackups fetches scheduled snapshots and returns AxonOpsBackup resources.
+func exportBackups(ctx context.Context, client *axonops.Client, opts *Options) ([]Resource, error) {
+	resp, err := client.GetScheduledSnapshots(ctx, opts.ClusterType, opts.ClusterName)
+	if err != nil {
+		return nil, fmt.Errorf("fetching backups: %w", err)
+	}
+	if resp == nil || len(resp.ScheduledSnapshots) == 0 {
+		return nil, nil
+	}
+
+	var resources []Resource
+	for _, snap := range resp.ScheduledSnapshots {
+		if len(snap.Params) == 0 {
+			continue
+		}
+		// The first element of Params is the backup config object containing BackupDetails
+		var param axonops.SnapshotParam
+		if err := json.Unmarshal(snap.Params[0], &param); err != nil {
+			return nil, fmt.Errorf("parsing backup params for %s: %w", snap.ID, err)
+		}
+		if param.BackupDetails == "" {
+			continue
+		}
+		// BackupDetails is itself a JSON string containing the full payload
+		var payload axonops.BackupPayload
+		if err := json.Unmarshal([]byte(param.BackupDetails), &payload); err != nil {
+			return nil, fmt.Errorf("parsing backup details for %s: %w", snap.ID, err)
+		}
+
+		tag := payload.Tag
+		if tag == "" {
+			tag = snap.ID
+		}
+		name := toDNSLabel(opts.ClusterName + "-" + tag)
+
+		// Reconstruct table references
+		var tables []string
+		for _, t := range payload.Tables {
+			tables = append(tables, t.Name)
+		}
+
+		schedule := payload.Schedule
+		obj := backupV1alpha1(name, opts, payload, tag, schedule, tables)
+		resources = append(resources, Resource{Kind: "AxonOpsBackup", Name: name, Object: obj})
+	}
+	return resources, nil
+}
+
+func backupV1alpha1(
+	name string, opts *Options, payload axonops.BackupPayload, tag string, schedule bool, tables []string,
+) any {
+	// Use raw map so we don't need to import a separate package here.
+	// The YAML marshaller handles this the same way as a typed struct.
+	spec := map[string]any{
+		"connectionRef":      opts.ConnectionName,
+		"clusterName":        opts.ClusterName,
+		"clusterType":        opts.ClusterType,
+		"tag":                tag,
+		"datacenters":        payload.Datacenters,
+		"schedule":           schedule,
+		"scheduleExpression": payload.ScheduleExpr,
+		"localRetention":     payload.LocalRetentionDuration,
+		"timeout":            payload.Timeout,
+	}
+	if len(payload.Nodes) > 0 {
+		spec["nodes"] = payload.Nodes
+	}
+	if len(payload.Keyspaces) > 0 {
+		spec["keyspaces"] = payload.Keyspaces
+	}
+	if len(tables) > 0 {
+		spec["tables"] = tables
+	}
+	if payload.Remote {
+		remote := map[string]any{
+			"type":      payload.RemoteType,
+			"path":      payload.RemotePath,
+			"retention": payload.RemoteRetentionDuration,
+		}
+		if payload.Transfers > 0 {
+			remote["transfers"] = payload.Transfers
+		}
+		if payload.BWLimit != "" {
+			remote["bwLimit"] = payload.BWLimit
+		}
+		if payload.TPSLimit > 0 {
+			remote["tpsLimit"] = payload.TPSLimit
+		}
+		spec["remote"] = remote
+	}
+
+	return map[string]any{
+		"apiVersion": "backups.axonops.com/v1alpha1",
+		"kind":       "AxonOpsBackup",
+		"metadata": map[string]any{
+			"name":      name,
+			"namespace": opts.Namespace,
+		},
+		"spec": spec,
+	}
+}

--- a/cmd/axonops-export/export/run.go
+++ b/cmd/axonops-export/export/run.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026.
+© 2026 AxonOps Limited. All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -113,16 +113,30 @@ func Run(ctx context.Context, opts *Options) error {
 	// Always generate AxonOpsConnection + Secret first
 	resources = append(resources, buildConnectionResources(opts)...)
 
-	// Export metric alerts
-	metricAlerts, err := exportMetricAlerts(ctx, client, opts)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: failed to export metric alerts: %v\n", err)
-	} else {
-		resources = append(resources, metricAlerts...)
-		fmt.Fprintf(os.Stderr, "  found %d metric alert(s)\n", len(metricAlerts))
+	type exportJob struct {
+		label string
+		fn    func(context.Context, *axonops.Client, *Options) ([]Resource, error)
+	}
+	jobs := []exportJob{
+		{"metric alerts", exportMetricAlerts},
+		{"log alerts", exportLogAlerts},
+		{"healthchecks", exportHealthchecks},
+		{"integrations", exportIntegrations},
+		{"adaptive repair", exportAdaptiveRepair},
+		{"scheduled repairs", exportScheduledRepairs},
+		{"backups", exportBackups},
+		{"silence windows", exportSilenceWindows},
 	}
 
-	// Future: export log alerts, healthchecks, alert routes, etc.
+	for _, job := range jobs {
+		items, err := job.fn(ctx, client, opts)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to export %s: %v\n", job.label, err)
+			continue
+		}
+		resources = append(resources, items...)
+		fmt.Fprintf(os.Stderr, "  found %d %s\n", len(items), job.label)
+	}
 
 	if len(resources) == 0 {
 		fmt.Fprintln(os.Stderr, "No resources to export")

--- a/cmd/axonops-export/export/silence.go
+++ b/cmd/axonops-export/export/silence.go
@@ -1,0 +1,70 @@
+/*
+© 2026 AxonOps Limited. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package export
+
+import (
+	"context"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	alertsv1alpha1 "github.com/axonops/axonops-operator/api/alerts/v1alpha1"
+	"github.com/axonops/axonops-operator/internal/axonops"
+)
+
+// exportSilenceWindows fetches silence windows and returns CRD resources.
+func exportSilenceWindows(ctx context.Context, client *axonops.Client, opts *Options) ([]Resource, error) {
+	silences, err := client.GetSilenceWindows(ctx, opts.ClusterType, opts.ClusterName)
+	if err != nil {
+		return nil, fmt.Errorf("fetching silence windows: %w", err)
+	}
+	if len(silences) == 0 {
+		return nil, nil
+	}
+
+	var resources []Resource
+	for i, sw := range silences {
+		name := toDNSLabel(fmt.Sprintf("%s-silence-%d", opts.ClusterName, i+1))
+		if sw.CronExpr != "" {
+			name = toDNSLabel(fmt.Sprintf("%s-silence-%s", opts.ClusterName, sw.CronExpr))
+		}
+
+		active := sw.Active
+		obj := &alertsv1alpha1.AxonOpsSilenceWindow{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "alerts.axonops.com/v1alpha1",
+				Kind:       "AxonOpsSilenceWindow",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: opts.Namespace,
+			},
+			Spec: alertsv1alpha1.AxonOpsSilenceWindowSpec{
+				ConnectionRef:  opts.ConnectionName,
+				ClusterName:    opts.ClusterName,
+				ClusterType:    opts.ClusterType,
+				Duration:       sw.Duration,
+				Active:         &active,
+				Recurring:      sw.IsRecurring,
+				CronExpression: sw.CronExpr,
+				Datacenters:    sw.DCs,
+			},
+		}
+		resources = append(resources, Resource{Kind: "AxonOpsSilenceWindow", Name: name, Object: obj})
+	}
+	return resources, nil
+}

--- a/cmd/axonops-export/export/writer.go
+++ b/cmd/axonops-export/export/writer.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026.
+© 2026 AxonOps Limited. All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/axonops-export/export/writer_test.go
+++ b/cmd/axonops-export/export/writer_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026.
+© 2026 AxonOps Limited. All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/internal/axonops/types.go
+++ b/internal/axonops/types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026.
+© 2026 AxonOps Limited. All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -177,13 +177,17 @@ type ScheduledSnapshotResponse struct {
 	ScheduledSnapshots []ScheduledSnapshot `json:"ScheduledSnapshots"`
 }
 
-// ScheduledSnapshot represents a single scheduled snapshot entry
+// ScheduledSnapshot represents a single scheduled snapshot entry.
+// The API returns Params as a heterogeneous JSON array: the first element is an
+// object containing the backup configuration (including BackupDetails as a
+// nested JSON string), and the remaining elements are plain strings (orgID,
+// clusterType, clusterName, snapshotID). We use RawMessage to handle this.
 type ScheduledSnapshot struct {
-	ID     string          `json:"ID"`
-	Params []SnapshotParam `json:"Params"`
+	ID     string            `json:"ID"`
+	Params []json.RawMessage `json:"Params"`
 }
 
-// SnapshotParam wraps the backup details JSON string
+// SnapshotParam wraps the backup details JSON string (first element of Params array).
 type SnapshotParam struct {
 	BackupDetails string `json:"BackupDetails"`
 }


### PR DESCRIPTION
## Description
Extends the `axonops-export` CLI to export all supported CRD types beyond the initial `AxonOpsMetricAlert` implementation. The tool can now produce a complete set of Kubernetes manifests from an existing AxonOps configuration.

## GitHub Issue
Closes #88

## Changes
- **Log alerts** — reuse the metric alert API, distinguish by `events{}` expression prefix, parse expression back into structured `content`/`level`/`source`/`logType` fields
- **Healthchecks** — export `AxonOpsHealthcheckHTTP`, `AxonOpsHealthcheckTCP`, `AxonOpsHealthcheckShell`
- **Integrations** — export `AxonOpsAlertEndpoint` (placeholder credentials) and `AxonOpsAlertRoute` (correct `integrationType` resolved from definition, route type normalised to CRD enum)
- **Repairs** — export `AxonOpsAdaptiveRepair` and `AxonOpsScheduledRepair`
- **Backups** — export `AxonOpsBackup`; fix `ScheduledSnapshot.Params` in `types.go` from `[]SnapshotParam` to `[]json.RawMessage` to handle the API's mixed-type array
- **Silence windows** — export `AxonOpsSilenceWindow`
- **run.go** — wires all 8 exporters via a unified job loop

## Testing
- [x] Manual testing against `axonops-webinar` cluster: 46 metric alerts, 18 log alerts, 9 healthchecks, 38 integrations/routes, 1 adaptive repair, 3 backups exported successfully
- [x] All existing tests pass (`make test`)
- [x] Lint clean (`make lint` — 0 issues)

## Breaking Changes
- [x] No breaking changes

## Checklist
- [x] Code follows style guidelines (`make fmt && make vet && make lint`)
- [x] Self-review of code completed
- [x] All tests pass (`make test`)

## Types of Changes
- [x] Feature (new functionality)