### PR TITLE
feat(drift-detection): add periodic drift detection to all controllers

### DIFF
--- a/internal/controller/alerts/axonopsadaptiverepair_controller.go
+++ b/internal/controller/alerts/axonopsadaptiverepair_controller.go
@@ -116,13 +116,14 @@ func (r *AxonOpsAdaptiveRepairReconciler) Reconcile(ctx context.Context, req ctr
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 	}
 
-	// Check if already synced and spec unchanged
+	// Check if already synced with drift detection
 	readyCond := meta.FindStatusCondition(repair.Status.Conditions, condTypeReady)
 	if readyCond != nil && readyCond.Status == metav1.ConditionTrue &&
 		repair.Status.ObservedGeneration == repair.Generation &&
 		repair.Status.LastSyncTime != nil {
-		log.Info("Adaptive repair already synced and spec unchanged, skipping API call")
-		return ctrl.Result{}, nil
+		if result, done, err := r.checkDrift(ctx, repair, apiClient); done {
+			return result, err
+		}
 	}
 
 	// Get current settings from API
@@ -163,6 +164,36 @@ func (r *AxonOpsAdaptiveRepairReconciler) Reconcile(ctx context.Context, req ctr
 }
 
 // handleDeletion handles cleanup when the CR is being deleted.
+// checkDrift verifies whether adaptive repair settings have drifted from the desired spec.
+// Returns (result, true, err) if the reconcile loop should return; (zero, false, nil) to continue.
+func (r *AxonOpsAdaptiveRepairReconciler) checkDrift(ctx context.Context, repair *alertsv1alpha1.AxonOpsAdaptiveRepair, apiClient *axonops.Client) (ctrl.Result, bool, error) {
+	log := logf.FromContext(ctx)
+	currentSettings, err := apiClient.GetAdaptiveRepair(ctx, repair.Spec.ClusterType, repair.Spec.ClusterName)
+	if err != nil {
+		log.Error(err, "Failed to perform drift check")
+		r.setFailedCondition(ctx, repair, "DriftCheckFailed", common.SafeConditionMsg("Failed to check for drift", err))
+		return ctrl.Result{RequeueAfter: common.DriftCheckInterval}, true, nil
+	}
+	desired := r.buildAdaptiveRepairSettings(repair)
+	if r.settingsEqual(desired, *currentSettings) {
+		log.Info("Adaptive repair already synced and spec unchanged, skipping API call")
+		return ctrl.Result{RequeueAfter: common.DriftCheckInterval}, true, nil
+	}
+	log.Info("Drift detected: adaptive repair settings have changed externally")
+	meta.SetStatusCondition(&repair.Status.Conditions, metav1.Condition{
+		Type:               "DriftDetected",
+		Status:             metav1.ConditionTrue,
+		ObservedGeneration: repair.Generation,
+		Reason:             "SettingsChanged",
+		Message:            "Adaptive repair settings were changed externally; reapplying",
+	})
+	repair.Status.LastSyncTime = nil
+	if statusErr := r.Status().Update(ctx, repair); statusErr != nil {
+		return ctrl.Result{}, true, statusErr
+	}
+	return ctrl.Result{}, false, nil
+}
+
 // Adaptive repair is a cluster-level singleton -- it cannot be "deleted" via the API.
 // The finalizer simply removes itself without making any API calls.
 func (r *AxonOpsAdaptiveRepairReconciler) handleDeletion(ctx context.Context, repair *alertsv1alpha1.AxonOpsAdaptiveRepair) error {

--- a/internal/controller/alerts/axonopsalertendpoint_controller.go
+++ b/internal/controller/alerts/axonopsalertendpoint_controller.go
@@ -110,14 +110,14 @@ func (r *AxonOpsAlertEndpointReconciler) Reconcile(ctx context.Context, req ctrl
 		return ctrl.Result{}, nil
 	}
 
-	// Idempotency check: skip if already synced and generation unchanged
+	// Idempotency check with drift detection
 	readyCond := meta.FindStatusCondition(endpoint.Status.Conditions, condTypeReady)
 	if readyCond != nil && readyCond.Status == metav1.ConditionTrue &&
 		endpoint.Status.ObservedGeneration == endpoint.Generation &&
 		endpoint.Status.SyncedIntegrationID != "" {
-		log.Info("Endpoint already synced, skipping reconciliation",
-			"integrationID", endpoint.Status.SyncedIntegrationID, "generation", endpoint.Generation)
-		return ctrl.Result{}, nil
+		if result, done, err := r.checkDrift(ctx, endpoint); done {
+			return result, err
+		}
 	}
 
 	log.Info("Reconciling AxonOpsAlertEndpoint",
@@ -225,6 +225,53 @@ func (r *AxonOpsAlertEndpointReconciler) Reconcile(ctx context.Context, req ctrl
 
 	log.Info("Successfully reconciled AxonOpsAlertEndpoint", "integrationID", result.ID)
 	return ctrl.Result{}, nil
+}
+
+// checkDrift verifies whether the synced integration still exists in AxonOps.
+// Resolves its own API client since the main Reconcile path doesn't do so until later.
+// Returns (result, true, err) if the reconcile loop should return; (zero, false, nil) to continue.
+func (r *AxonOpsAlertEndpointReconciler) checkDrift(ctx context.Context, endpoint *alertsv1alpha1.AxonOpsAlertEndpoint) (ctrl.Result, bool, error) {
+	log := logf.FromContext(ctx)
+	apiClient, err := ResolveAPIClient(ctx, r.Client, endpoint.Namespace, endpoint.Spec.ConnectionRef)
+	if err != nil {
+		log.Error(err, "Failed to resolve API client for drift check")
+		return ctrl.Result{RequeueAfter: common.DriftCheckInterval}, true, nil
+	}
+	integrations, err := apiClient.GetIntegrations(ctx, endpoint.Spec.ClusterType, endpoint.Spec.ClusterName)
+	if err != nil {
+		log.Error(err, "Failed to perform drift check")
+		meta.SetStatusCondition(&endpoint.Status.Conditions, metav1.Condition{
+			Type:               "DriftCheckFailed",
+			Status:             metav1.ConditionTrue,
+			ObservedGeneration: endpoint.Generation,
+			Reason:             "DriftCheckFailed",
+			Message:            common.SafeConditionMsg("Failed to check for drift", err),
+		})
+		if statusErr := r.Status().Update(ctx, endpoint); statusErr != nil {
+			log.Error(statusErr, "Failed to update status")
+		}
+		return ctrl.Result{RequeueAfter: common.DriftCheckInterval}, true, nil
+	}
+	for _, def := range integrations.Definitions {
+		if def.ID == endpoint.Status.SyncedIntegrationID {
+			log.Info("Endpoint already synced, skipping reconciliation",
+				"integrationID", endpoint.Status.SyncedIntegrationID, "generation", endpoint.Generation)
+			return ctrl.Result{RequeueAfter: common.DriftCheckInterval}, true, nil
+		}
+	}
+	log.Info("Drift detected: integration no longer exists in AxonOps", "integrationID", endpoint.Status.SyncedIntegrationID)
+	meta.SetStatusCondition(&endpoint.Status.Conditions, metav1.Condition{
+		Type:               "DriftDetected",
+		Status:             metav1.ConditionTrue,
+		ObservedGeneration: endpoint.Generation,
+		Reason:             "ResourceDeleted",
+		Message:            "Integration was deleted externally; recreating",
+	})
+	endpoint.Status.SyncedIntegrationID = ""
+	if statusErr := r.Status().Update(ctx, endpoint); statusErr != nil {
+		return ctrl.Result{}, true, statusErr
+	}
+	return ctrl.Result{}, false, nil
 }
 
 // handleDeletion handles cleanup when the CR is being deleted

--- a/internal/controller/alerts/axonopsalertroute_controller.go
+++ b/internal/controller/alerts/axonopsalertroute_controller.go
@@ -112,14 +112,14 @@ func (r *AxonOpsAlertRouteReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		return ctrl.Result{}, nil
 	}
 
-	// Check idempotency: skip if already synced and generation unchanged
+	// Check idempotency with drift detection
 	readyCond := meta.FindStatusCondition(route.Status.Conditions, condTypeReady)
 	if readyCond != nil && readyCond.Status == metav1.ConditionTrue &&
 		route.Status.ObservedGeneration == route.Generation &&
 		route.Status.IntegrationID != "" {
-		log.Info("Route already synced, skipping reconciliation",
-			"integrationID", route.Status.IntegrationID, "generation", route.Generation)
-		return ctrl.Result{}, nil
+		if result, done, err := r.checkDrift(ctx, route); done {
+			return result, err
+		}
 	}
 
 	log.Info("Reconciling AxonOpsAlertRoute",
@@ -199,50 +199,10 @@ func (r *AxonOpsAlertRouteReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		return ctrl.Result{}, err
 	}
 
-	// Check if route already exists
+	// Set override and add route if needed
 	routeExists := checkRouteExists(integrations, apiRouteType, route.Spec.Severity, integrationID)
-
-	// Set override if non-global and enabled (defaults to true when nil)
-	enableOverride := route.Spec.EnableOverride == nil || *route.Spec.EnableOverride
-	if route.Spec.Type != "global" && enableOverride {
-		log.Info("Setting integration override", "routeType", apiRouteType, "severity", route.Spec.Severity)
-		if err := apiClient.SetIntegrationOverride(ctx, route.Spec.ClusterType, route.Spec.ClusterName,
-			apiRouteType, route.Spec.Severity, true); err != nil {
-			log.Error(err, "Failed to set integration override")
-			meta.SetStatusCondition(&route.Status.Conditions, metav1.Condition{
-				Type:               condTypeReady,
-				Status:             metav1.ConditionFalse,
-				Reason:             "OverrideError",
-				Message:            common.SafeConditionMsg("Failed to set override", err),
-				ObservedGeneration: route.Generation,
-			})
-			if err := r.Status().Update(ctx, route); err != nil {
-				log.Error(err, "Failed to update status")
-			}
-			return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
-		}
-	}
-
-	// Add route if it doesn't exist
-	if !routeExists {
-		log.Info("Adding integration route", "integrationID", integrationID, "routeType", apiRouteType, "severity", route.Spec.Severity)
-		if err := apiClient.AddIntegrationRoute(ctx, route.Spec.ClusterType, route.Spec.ClusterName,
-			apiRouteType, route.Spec.Severity, integrationID); err != nil {
-			log.Error(err, "Failed to add integration route")
-			meta.SetStatusCondition(&route.Status.Conditions, metav1.Condition{
-				Type:               condTypeReady,
-				Status:             metav1.ConditionFalse,
-				Reason:             "RouteError",
-				Message:            common.SafeConditionMsg("Failed to add route", err),
-				ObservedGeneration: route.Generation,
-			})
-			if err := r.Status().Update(ctx, route); err != nil {
-				log.Error(err, "Failed to update status")
-			}
-			return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
-		}
-	} else {
-		log.Info("Route already exists, skipping creation")
+	if result, stop := r.applyRoute(ctx, apiClient, route, apiRouteType, integrationID, routeExists); stop {
+		return result, nil
 	}
 
 	// Update status
@@ -268,6 +228,98 @@ func (r *AxonOpsAlertRouteReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 	log.Info("Successfully reconciled AxonOpsAlertRoute")
 	return ctrl.Result{}, nil
+}
+
+// applyRoute sets the integration override (if needed) and adds the route (if missing).
+// Returns (result, true) if the reconcile loop should stop.
+func (r *AxonOpsAlertRouteReconciler) applyRoute(ctx context.Context, apiClient *axonops.Client, route *alertsv1alpha1.AxonOpsAlertRoute, apiRouteType, integrationID string, routeExists bool) (ctrl.Result, bool) {
+	log := logf.FromContext(ctx)
+
+	enableOverride := route.Spec.EnableOverride == nil || *route.Spec.EnableOverride
+	if route.Spec.Type != "global" && enableOverride {
+		log.Info("Setting integration override", "routeType", apiRouteType, "severity", route.Spec.Severity)
+		if err := apiClient.SetIntegrationOverride(ctx, route.Spec.ClusterType, route.Spec.ClusterName,
+			apiRouteType, route.Spec.Severity, true); err != nil {
+			log.Error(err, "Failed to set integration override")
+			meta.SetStatusCondition(&route.Status.Conditions, metav1.Condition{
+				Type:               condTypeReady,
+				Status:             metav1.ConditionFalse,
+				Reason:             "OverrideError",
+				Message:            common.SafeConditionMsg("Failed to set override", err),
+				ObservedGeneration: route.Generation,
+			})
+			if statusErr := r.Status().Update(ctx, route); statusErr != nil {
+				log.Error(statusErr, "Failed to update status")
+			}
+			return ctrl.Result{RequeueAfter: 30 * time.Second}, true
+		}
+	}
+
+	if routeExists {
+		log.Info("Route already exists, skipping creation")
+		return ctrl.Result{}, false
+	}
+
+	log.Info("Adding integration route", "integrationID", integrationID, "routeType", apiRouteType, "severity", route.Spec.Severity)
+	if err := apiClient.AddIntegrationRoute(ctx, route.Spec.ClusterType, route.Spec.ClusterName,
+		apiRouteType, route.Spec.Severity, integrationID); err != nil {
+		log.Error(err, "Failed to add integration route")
+		meta.SetStatusCondition(&route.Status.Conditions, metav1.Condition{
+			Type:               condTypeReady,
+			Status:             metav1.ConditionFalse,
+			Reason:             "RouteError",
+			Message:            common.SafeConditionMsg("Failed to add route", err),
+			ObservedGeneration: route.Generation,
+		})
+		if statusErr := r.Status().Update(ctx, route); statusErr != nil {
+			log.Error(statusErr, "Failed to update status")
+		}
+		return ctrl.Result{RequeueAfter: 30 * time.Second}, true
+	}
+	return ctrl.Result{}, false
+}
+
+// checkDrift verifies whether the alert route still exists in AxonOps.
+// Returns (result, true, err) if the reconcile loop should return; (zero, false, nil) to continue.
+func (r *AxonOpsAlertRouteReconciler) checkDrift(ctx context.Context, route *alertsv1alpha1.AxonOpsAlertRoute) (ctrl.Result, bool, error) {
+	log := logf.FromContext(ctx)
+	apiClient, err := ResolveAPIClient(ctx, r.Client, route.Namespace, route.Spec.ConnectionRef)
+	if err != nil {
+		log.Error(err, "Failed to resolve API client for drift check")
+		return ctrl.Result{RequeueAfter: common.DriftCheckInterval}, true, nil
+	}
+	integrations, err := apiClient.GetIntegrations(ctx, route.Spec.ClusterType, route.Spec.ClusterName)
+	if err != nil {
+		log.Error(err, "Failed to get integrations during drift check")
+		meta.SetStatusCondition(&route.Status.Conditions, metav1.Condition{
+			Type:               "DriftCheckFailed",
+			Status:             metav1.ConditionTrue,
+			ObservedGeneration: route.Generation,
+			Reason:             "APIError",
+			Message:            common.SafeConditionMsg("Failed to check for drift", err),
+		})
+		if statusErr := r.Status().Update(ctx, route); statusErr != nil {
+			log.Error(statusErr, "Failed to update status after drift check failure")
+		}
+		return ctrl.Result{RequeueAfter: common.DriftCheckInterval}, true, nil
+	}
+	apiRouteType, _ := getAPIRouteType(route.Spec.Type)
+	if checkRouteExists(integrations, apiRouteType, route.Spec.Severity, route.Status.IntegrationID) {
+		return ctrl.Result{RequeueAfter: common.DriftCheckInterval}, true, nil
+	}
+	log.Info("Drift detected: alert route no longer exists in AxonOps, will recreate")
+	meta.SetStatusCondition(&route.Status.Conditions, metav1.Condition{
+		Type:               "DriftDetected",
+		Status:             metav1.ConditionTrue,
+		ObservedGeneration: route.Generation,
+		Reason:             "ResourceDeleted",
+		Message:            "Alert route was deleted externally; reapplying",
+	})
+	route.Status.IntegrationID = ""
+	if statusErr := r.Status().Update(ctx, route); statusErr != nil {
+		return ctrl.Result{}, true, statusErr
+	}
+	return ctrl.Result{}, false, nil
 }
 
 // handleDeletion handles cleanup when the CR is being deleted

--- a/internal/controller/alerts/axonopscommitlogarchive_controller.go
+++ b/internal/controller/alerts/axonopscommitlogarchive_controller.go
@@ -115,8 +115,9 @@ func (r *AxonOpsCommitlogArchiveReconciler) Reconcile(ctx context.Context, req c
 	if readyCond != nil && readyCond.Status == metav1.ConditionTrue &&
 		archive.Status.ObservedGeneration == archive.Generation &&
 		archive.Status.LastSyncTime != nil {
-		log.Info("Commitlog archive already synced and spec unchanged, skipping")
-		return ctrl.Result{}, nil
+		if result, done, err := r.checkDrift(ctx, archive, apiClient); done {
+			return result, err
+		}
 	}
 
 	if err := r.validateConfig(archive); err != nil {
@@ -193,6 +194,35 @@ func (r *AxonOpsCommitlogArchiveReconciler) Reconcile(ctx context.Context, req c
 
 	log.Info("Successfully synced commitlog archive settings", "remoteType", archive.Spec.RemoteType)
 	return ctrl.Result{}, nil
+}
+
+// checkDrift verifies whether commitlog archive settings still exist in AxonOps.
+// Returns (result, true, err) if the reconcile loop should return; (zero, false, nil) to continue.
+func (r *AxonOpsCommitlogArchiveReconciler) checkDrift(ctx context.Context, archive *alertsv1alpha1.AxonOpsCommitlogArchive, apiClient *axonops.Client) (ctrl.Result, bool, error) {
+	log := logf.FromContext(ctx)
+	settings, err := apiClient.GetCommitlogArchiveSettings(ctx, archive.Spec.ClusterType, archive.Spec.ClusterName)
+	if err != nil {
+		log.Error(err, "Failed to perform drift check")
+		r.setFailedCondition(ctx, archive, "DriftCheckFailed", common.SafeConditionMsg("Failed to check for drift", err))
+		return ctrl.Result{RequeueAfter: common.DriftCheckInterval}, true, nil
+	}
+	if len(settings) > 0 {
+		log.Info("Commitlog archive already synced and spec unchanged, skipping")
+		return ctrl.Result{RequeueAfter: common.DriftCheckInterval}, true, nil
+	}
+	log.Info("Drift detected: commitlog archive settings no longer exist in AxonOps")
+	meta.SetStatusCondition(&archive.Status.Conditions, metav1.Condition{
+		Type:               "DriftDetected",
+		Status:             metav1.ConditionTrue,
+		ObservedGeneration: archive.Generation,
+		Reason:             "ResourceDeleted",
+		Message:            "Commitlog archive settings were removed externally; recreating",
+	})
+	archive.Status.LastSyncTime = nil
+	if statusErr := r.Status().Update(ctx, archive); statusErr != nil {
+		return ctrl.Result{}, true, statusErr
+	}
+	return ctrl.Result{}, false, nil
 }
 
 func (r *AxonOpsCommitlogArchiveReconciler) validateConfig(archive *alertsv1alpha1.AxonOpsCommitlogArchive) error {

--- a/internal/controller/alerts/axonopsdashboardtemplate_controller.go
+++ b/internal/controller/alerts/axonopsdashboardtemplate_controller.go
@@ -120,13 +120,14 @@ func (r *AxonOpsDashboardTemplateReconciler) Reconcile(ctx context.Context, req 
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 	}
 
-	// Check if already synced and spec unchanged
+	// Check if already synced with drift detection
 	readyCond := meta.FindStatusCondition(dashboard.Status.Conditions, condTypeReady)
 	if readyCond != nil && readyCond.Status == metav1.ConditionTrue &&
 		dashboard.Status.ObservedGeneration == dashboard.Generation &&
 		dashboard.Status.LastSyncTime != nil {
-		log.Info("Dashboard template already synced and spec unchanged, skipping API call")
-		return ctrl.Result{}, nil
+		if result, done, err := r.checkDrift(ctx, dashboard, apiClient); done {
+			return result, err
+		}
 	}
 
 	// Validate and resolve source
@@ -214,6 +215,44 @@ func (r *AxonOpsDashboardTemplateReconciler) Reconcile(ctx context.Context, req 
 
 	log.Info("Successfully synced dashboard template", "dashboard", dashboard.Spec.DashboardName, "panelCount", panelCount)
 	return ctrl.Result{}, nil
+}
+
+// checkDrift verifies whether dashboard templates still exist in AxonOps.
+// Returns (result, true, err) if the reconcile loop should return; (zero, false, nil) to continue.
+func (r *AxonOpsDashboardTemplateReconciler) checkDrift(ctx context.Context, dashboard *alertsv1alpha1.AxonOpsDashboardTemplate, apiClient *axonops.Client) (ctrl.Result, bool, error) {
+	log := logf.FromContext(ctx)
+	templates, err := apiClient.GetDashboardTemplates(ctx, dashboard.Spec.ClusterType, dashboard.Spec.ClusterName)
+	if err != nil {
+		log.Error(err, "Failed to perform drift check")
+		meta.SetStatusCondition(&dashboard.Status.Conditions, metav1.Condition{
+			Type:               "DriftCheckFailed",
+			Status:             metav1.ConditionTrue,
+			ObservedGeneration: dashboard.Generation,
+			Reason:             "DriftCheckFailed",
+			Message:            common.SafeConditionMsg("Failed to check for drift", err),
+		})
+		if statusErr := r.Status().Update(ctx, dashboard); statusErr != nil {
+			log.Error(statusErr, "Failed to update status")
+		}
+		return ctrl.Result{RequeueAfter: common.DriftCheckInterval}, true, nil
+	}
+	if len(templates.Dashboards) > 0 {
+		log.Info("Dashboard template already synced and spec unchanged, skipping API call")
+		return ctrl.Result{RequeueAfter: common.DriftCheckInterval}, true, nil
+	}
+	log.Info("Drift detected: dashboard templates no longer exist in AxonOps")
+	meta.SetStatusCondition(&dashboard.Status.Conditions, metav1.Condition{
+		Type:               "DriftDetected",
+		Status:             metav1.ConditionTrue,
+		ObservedGeneration: dashboard.Generation,
+		Reason:             "ResourceDeleted",
+		Message:            "Dashboard templates were removed externally; recreating",
+	})
+	dashboard.Status.LastSyncTime = nil
+	if statusErr := r.Status().Update(ctx, dashboard); statusErr != nil {
+		return ctrl.Result{}, true, statusErr
+	}
+	return ctrl.Result{}, false, nil
 }
 
 // resolveSource validates and resolves the dashboard source.

--- a/internal/controller/alerts/axonopshealthcheckhttp_controller.go
+++ b/internal/controller/alerts/axonopshealthcheckhttp_controller.go
@@ -112,13 +112,14 @@ func (r *AxonOpsHealthcheckHTTPReconciler) Reconcile(ctx context.Context, req ct
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 	}
 
-	// Check if healthcheck is already synced
+	// Check if healthcheck is already synced with drift detection
 	readyCond := meta.FindStatusCondition(healthcheck.Status.Conditions, condTypeReady)
 	if readyCond != nil && readyCond.Status == metav1.ConditionTrue &&
 		healthcheck.Status.ObservedGeneration == healthcheck.Generation &&
 		healthcheck.Status.SyncedHealthcheckID != "" {
-		log.Info("Healthcheck already synced and spec unchanged, skipping API call")
-		return ctrl.Result{}, nil
+		if result, done, err := r.checkDrift(ctx, healthcheck, apiClient); done {
+			return result, err
+		}
 	}
 
 	// Get all healthchecks from API
@@ -188,6 +189,37 @@ func (r *AxonOpsHealthcheckHTTPReconciler) Reconcile(ctx context.Context, req ct
 
 	log.Info("Successfully synced HTTP healthcheck", "healthcheckID", syncedID)
 	return ctrl.Result{}, nil
+}
+
+// checkDrift verifies whether the synced HTTP healthcheck still exists in AxonOps.
+// Returns (result, true, err) if the reconcile loop should return; (zero, false, nil) to continue.
+func (r *AxonOpsHealthcheckHTTPReconciler) checkDrift(ctx context.Context, healthcheck *alertsv1alpha1.AxonOpsHealthcheckHTTP, apiClient *axonops.Client) (ctrl.Result, bool, error) {
+	log := logf.FromContext(ctx)
+	allHealthchecks, err := apiClient.GetHealthchecks(ctx, healthcheck.Spec.ClusterType, healthcheck.Spec.ClusterName)
+	if err != nil {
+		log.Error(err, "Failed to perform drift check")
+		r.setFailedCondition(ctx, healthcheck, "DriftCheckFailed", common.SafeConditionMsg("Failed to check for drift", err))
+		return ctrl.Result{RequeueAfter: common.DriftCheckInterval}, true, nil
+	}
+	for _, hc := range allHealthchecks.HTTPChecks {
+		if hc.ID == healthcheck.Status.SyncedHealthcheckID {
+			log.Info("Healthcheck already synced and spec unchanged, skipping API call")
+			return ctrl.Result{RequeueAfter: common.DriftCheckInterval}, true, nil
+		}
+	}
+	log.Info("Drift detected: HTTP healthcheck no longer exists in AxonOps", "healthcheckID", healthcheck.Status.SyncedHealthcheckID)
+	meta.SetStatusCondition(&healthcheck.Status.Conditions, metav1.Condition{
+		Type:               "DriftDetected",
+		Status:             metav1.ConditionTrue,
+		ObservedGeneration: healthcheck.Generation,
+		Reason:             "ResourceDeleted",
+		Message:            "HTTP healthcheck was deleted externally; recreating",
+	})
+	healthcheck.Status.SyncedHealthcheckID = ""
+	if statusErr := r.Status().Update(ctx, healthcheck); statusErr != nil {
+		return ctrl.Result{}, true, statusErr
+	}
+	return ctrl.Result{}, false, nil
 }
 
 // handleDeletion handles cleanup when the CR is being deleted

--- a/internal/controller/alerts/axonopshealthcheckshell_controller.go
+++ b/internal/controller/alerts/axonopshealthcheckshell_controller.go
@@ -112,13 +112,14 @@ func (r *AxonOpsHealthcheckShellReconciler) Reconcile(ctx context.Context, req c
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 	}
 
-	// Check if healthcheck is already synced
+	// Check if healthcheck is already synced with drift detection
 	readyCond := meta.FindStatusCondition(healthcheck.Status.Conditions, condTypeReady)
 	if readyCond != nil && readyCond.Status == metav1.ConditionTrue &&
 		healthcheck.Status.ObservedGeneration == healthcheck.Generation &&
 		healthcheck.Status.SyncedHealthcheckID != "" {
-		log.Info("Healthcheck already synced and spec unchanged, skipping API call")
-		return ctrl.Result{}, nil
+		if result, done, err := r.checkDrift(ctx, healthcheck, apiClient); done {
+			return result, err
+		}
 	}
 
 	// Get all healthchecks from API
@@ -188,6 +189,37 @@ func (r *AxonOpsHealthcheckShellReconciler) Reconcile(ctx context.Context, req c
 
 	log.Info("Successfully synced Shell healthcheck", "healthcheckID", syncedID)
 	return ctrl.Result{}, nil
+}
+
+// checkDrift verifies whether the synced shell healthcheck still exists in AxonOps.
+// Returns (result, true, err) if the reconcile loop should return; (zero, false, nil) to continue.
+func (r *AxonOpsHealthcheckShellReconciler) checkDrift(ctx context.Context, healthcheck *alertsv1alpha1.AxonOpsHealthcheckShell, apiClient *axonops.Client) (ctrl.Result, bool, error) {
+	log := logf.FromContext(ctx)
+	allHealthchecks, err := apiClient.GetHealthchecks(ctx, healthcheck.Spec.ClusterType, healthcheck.Spec.ClusterName)
+	if err != nil {
+		log.Error(err, "Failed to perform drift check")
+		r.setFailedCondition(ctx, healthcheck, "DriftCheckFailed", common.SafeConditionMsg("Failed to check for drift", err))
+		return ctrl.Result{RequeueAfter: common.DriftCheckInterval}, true, nil
+	}
+	for _, hc := range allHealthchecks.ShellChecks {
+		if hc.ID == healthcheck.Status.SyncedHealthcheckID {
+			log.Info("Healthcheck already synced and spec unchanged, skipping API call")
+			return ctrl.Result{RequeueAfter: common.DriftCheckInterval}, true, nil
+		}
+	}
+	log.Info("Drift detected: shell healthcheck no longer exists in AxonOps", "healthcheckID", healthcheck.Status.SyncedHealthcheckID)
+	meta.SetStatusCondition(&healthcheck.Status.Conditions, metav1.Condition{
+		Type:               "DriftDetected",
+		Status:             metav1.ConditionTrue,
+		ObservedGeneration: healthcheck.Generation,
+		Reason:             "ResourceDeleted",
+		Message:            "Shell healthcheck was deleted externally; recreating",
+	})
+	healthcheck.Status.SyncedHealthcheckID = ""
+	if statusErr := r.Status().Update(ctx, healthcheck); statusErr != nil {
+		return ctrl.Result{}, true, statusErr
+	}
+	return ctrl.Result{}, false, nil
 }
 
 // handleDeletion handles cleanup when the CR is being deleted

--- a/internal/controller/alerts/axonopshealthchecktcp_controller.go
+++ b/internal/controller/alerts/axonopshealthchecktcp_controller.go
@@ -112,13 +112,14 @@ func (r *AxonOpsHealthcheckTCPReconciler) Reconcile(ctx context.Context, req ctr
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 	}
 
-	// Check if healthcheck is already synced
+	// Check if healthcheck is already synced with drift detection
 	readyCond := meta.FindStatusCondition(healthcheck.Status.Conditions, condTypeReady)
 	if readyCond != nil && readyCond.Status == metav1.ConditionTrue &&
 		healthcheck.Status.ObservedGeneration == healthcheck.Generation &&
 		healthcheck.Status.SyncedHealthcheckID != "" {
-		log.Info("Healthcheck already synced and spec unchanged, skipping API call")
-		return ctrl.Result{}, nil
+		if result, done, err := r.checkDrift(ctx, healthcheck, apiClient); done {
+			return result, err
+		}
 	}
 
 	// Get all healthchecks from API
@@ -188,6 +189,37 @@ func (r *AxonOpsHealthcheckTCPReconciler) Reconcile(ctx context.Context, req ctr
 
 	log.Info("Successfully synced TCP healthcheck", "healthcheckID", syncedID)
 	return ctrl.Result{}, nil
+}
+
+// checkDrift verifies whether the synced TCP healthcheck still exists in AxonOps.
+// Returns (result, true, err) if the reconcile loop should return; (zero, false, nil) to continue.
+func (r *AxonOpsHealthcheckTCPReconciler) checkDrift(ctx context.Context, healthcheck *alertsv1alpha1.AxonOpsHealthcheckTCP, apiClient *axonops.Client) (ctrl.Result, bool, error) {
+	log := logf.FromContext(ctx)
+	allHealthchecks, err := apiClient.GetHealthchecks(ctx, healthcheck.Spec.ClusterType, healthcheck.Spec.ClusterName)
+	if err != nil {
+		log.Error(err, "Failed to perform drift check")
+		r.setFailedCondition(ctx, healthcheck, "DriftCheckFailed", common.SafeConditionMsg("Failed to check for drift", err))
+		return ctrl.Result{RequeueAfter: common.DriftCheckInterval}, true, nil
+	}
+	for _, hc := range allHealthchecks.TCPChecks {
+		if hc.ID == healthcheck.Status.SyncedHealthcheckID {
+			log.Info("Healthcheck already synced and spec unchanged, skipping API call")
+			return ctrl.Result{RequeueAfter: common.DriftCheckInterval}, true, nil
+		}
+	}
+	log.Info("Drift detected: TCP healthcheck no longer exists in AxonOps", "healthcheckID", healthcheck.Status.SyncedHealthcheckID)
+	meta.SetStatusCondition(&healthcheck.Status.Conditions, metav1.Condition{
+		Type:               "DriftDetected",
+		Status:             metav1.ConditionTrue,
+		ObservedGeneration: healthcheck.Generation,
+		Reason:             "ResourceDeleted",
+		Message:            "TCP healthcheck was deleted externally; recreating",
+	})
+	healthcheck.Status.SyncedHealthcheckID = ""
+	if statusErr := r.Status().Update(ctx, healthcheck); statusErr != nil {
+		return ctrl.Result{}, true, statusErr
+	}
+	return ctrl.Result{}, false, nil
 }
 
 // handleDeletion handles cleanup when the CR is being deleted

--- a/internal/controller/alerts/axonopslogalert_controller.go
+++ b/internal/controller/alerts/axonopslogalert_controller.go
@@ -125,13 +125,14 @@ func (r *AxonOpsLogAlertReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 	}
 
-	// Check if alert is already synced with observed generation matching
+	// Check if alert is already synced with drift detection
 	readyCond := meta.FindStatusCondition(alert.Status.Conditions, logAlertCondTypeReady)
 	if readyCond != nil && readyCond.Status == metav1.ConditionTrue &&
 		alert.Status.ObservedGeneration == alert.Generation &&
 		alert.Status.SyncedAlertID != "" {
-		log.Info("Alert already synced and spec unchanged, skipping API call")
-		return ctrl.Result{}, nil
+		if result, done, err := r.checkDrift(ctx, alert, apiClient); done {
+			return result, err
+		}
 	}
 
 	// Set Progressing condition
@@ -203,6 +204,46 @@ func (r *AxonOpsLogAlertReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	log.Info("Successfully synced alert rule", "alertID", result.ID)
 	return ctrl.Result{}, nil
+}
+
+// checkDrift verifies whether the synced log alert rule still exists in AxonOps.
+// Returns (result, true, err) if the reconcile loop should return; (zero, false, nil) to continue.
+func (r *AxonOpsLogAlertReconciler) checkDrift(ctx context.Context, alert *alertsv1alpha1.AxonOpsLogAlert, apiClient *axonops.Client) (ctrl.Result, bool, error) {
+	log := logf.FromContext(ctx)
+	rules, err := apiClient.GetMetricAlertRules(ctx, alert.Spec.ClusterType, alert.Spec.ClusterName)
+	if err != nil {
+		log.Error(err, "Failed to perform drift check")
+		meta.SetStatusCondition(&alert.Status.Conditions, metav1.Condition{
+			Type:               "DriftCheckFailed",
+			Status:             metav1.ConditionTrue,
+			ObservedGeneration: alert.Generation,
+			Reason:             "DriftCheckFailed",
+			Message:            common.SafeConditionMsg("Failed to check for drift", err),
+		})
+		if statusErr := r.Status().Update(ctx, alert); statusErr != nil {
+			log.Error(statusErr, "Failed to update status")
+		}
+		return ctrl.Result{RequeueAfter: common.DriftCheckInterval}, true, nil
+	}
+	for _, rule := range rules {
+		if rule.ID == alert.Status.SyncedAlertID {
+			log.Info("Alert already synced and spec unchanged, skipping API call")
+			return ctrl.Result{RequeueAfter: common.DriftCheckInterval}, true, nil
+		}
+	}
+	log.Info("Drift detected: log alert rule no longer exists in AxonOps", "alertID", alert.Status.SyncedAlertID)
+	meta.SetStatusCondition(&alert.Status.Conditions, metav1.Condition{
+		Type:               "DriftDetected",
+		Status:             metav1.ConditionTrue,
+		ObservedGeneration: alert.Generation,
+		Reason:             "ResourceDeleted",
+		Message:            "Log alert rule was deleted externally; recreating",
+	})
+	alert.Status.SyncedAlertID = ""
+	if statusErr := r.Status().Update(ctx, alert); statusErr != nil {
+		return ctrl.Result{}, true, statusErr
+	}
+	return ctrl.Result{}, false, nil
 }
 
 // handleDeletion handles cleanup when the CR is being deleted

--- a/internal/controller/alerts/axonopslogcollector_controller.go
+++ b/internal/controller/alerts/axonopslogcollector_controller.go
@@ -114,13 +114,14 @@ func (r *AxonOpsLogCollectorReconciler) Reconcile(ctx context.Context, req ctrl.
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 	}
 
-	// Check idempotency
+	// Check idempotency with drift detection
 	readyCond := meta.FindStatusCondition(cr.Status.Conditions, condTypeReady)
 	if readyCond != nil && readyCond.Status == metav1.ConditionTrue &&
 		cr.Status.ObservedGeneration == cr.Generation &&
 		cr.Status.SyncedUUID != "" {
-		log.Info("Log collector already synced and spec unchanged, skipping API call")
-		return ctrl.Result{}, nil
+		if result, done, err := r.checkDrift(ctx, cr, apiClient); done {
+			return result, err
+		}
 	}
 
 	// GET current list of log collectors
@@ -228,6 +229,46 @@ func (r *AxonOpsLogCollectorReconciler) Reconcile(ctx context.Context, req ctrl.
 
 	log.Info("Successfully synced log collector", "uuid", collectorUUID)
 	return ctrl.Result{}, nil
+}
+
+// checkDrift verifies whether the synced log collector still exists in AxonOps.
+// Returns (result, true, err) if the reconcile loop should return; (zero, false, nil) to continue.
+func (r *AxonOpsLogCollectorReconciler) checkDrift(ctx context.Context, cr *alertsv1alpha1.AxonOpsLogCollector, apiClient *axonops.Client) (ctrl.Result, bool, error) {
+	log := logf.FromContext(ctx)
+	collectors, err := apiClient.GetLogCollectors(ctx, cr.Spec.ClusterType, cr.Spec.ClusterName)
+	if err != nil {
+		log.Error(err, "Failed to perform drift check")
+		meta.SetStatusCondition(&cr.Status.Conditions, metav1.Condition{
+			Type:               "DriftCheckFailed",
+			Status:             metav1.ConditionTrue,
+			ObservedGeneration: cr.Generation,
+			Reason:             "DriftCheckFailed",
+			Message:            common.SafeConditionMsg("Failed to check for drift", err),
+		})
+		if statusErr := r.Status().Update(ctx, cr); statusErr != nil {
+			log.Error(statusErr, "Failed to update status")
+		}
+		return ctrl.Result{RequeueAfter: common.DriftCheckInterval}, true, nil
+	}
+	for _, lc := range collectors {
+		if lc.UUID == cr.Status.SyncedUUID {
+			log.Info("Log collector already synced and spec unchanged, skipping API call")
+			return ctrl.Result{RequeueAfter: common.DriftCheckInterval}, true, nil
+		}
+	}
+	log.Info("Drift detected: log collector no longer exists in AxonOps", "uuid", cr.Status.SyncedUUID)
+	meta.SetStatusCondition(&cr.Status.Conditions, metav1.Condition{
+		Type:               "DriftDetected",
+		Status:             metav1.ConditionTrue,
+		ObservedGeneration: cr.Generation,
+		Reason:             "ResourceDeleted",
+		Message:            "Log collector was deleted externally; recreating",
+	})
+	cr.Status.SyncedUUID = ""
+	if statusErr := r.Status().Update(ctx, cr); statusErr != nil {
+		return ctrl.Result{}, true, statusErr
+	}
+	return ctrl.Result{}, false, nil
 }
 
 func (r *AxonOpsLogCollectorReconciler) handleDeletion(ctx context.Context, cr *alertsv1alpha1.AxonOpsLogCollector) (ctrl.Result, error) {

--- a/internal/controller/alerts/axonopslogcollector_controller_test.go
+++ b/internal/controller/alerts/axonopslogcollector_controller_test.go
@@ -239,16 +239,25 @@ var _ = Describe("AxonOpsLogCollector Controller", func() {
 		})
 	})
 
-	Context("Reconcile_Idempotent_NoApiCallWhenSynced", func() {
-		It("should not call API when already synced", func() {
-			var apiCallCount atomic.Int32
+	Context("Reconcile_Idempotent_NoResyncWhenSynced", func() {
+		It("should only perform a drift-check GET and not re-sync when already synced", func() {
+			var getCalls, putCalls atomic.Int32
+			var syncedUUID string
+
 			server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				apiCallCount.Add(1)
 				switch r.Method {
 				case http.MethodGet:
+					getCalls.Add(1)
 					w.WriteHeader(http.StatusOK)
-					_, _ = w.Write([]byte(`[]`))
+					if syncedUUID != "" {
+						collectors := []axonops.LogCollector{{UUID: syncedUUID, Filename: "/var/log/cassandra/idem.log"}}
+						data, _ := json.Marshal(collectors)
+						_, _ = w.Write(data)
+					} else {
+						_, _ = w.Write([]byte(`[]`))
+					}
 				case http.MethodPut:
+					putCalls.Add(1)
 					w.WriteHeader(http.StatusOK)
 				default:
 					w.WriteHeader(http.StatusOK)
@@ -267,18 +276,24 @@ var _ = Describe("AxonOpsLogCollector Controller", func() {
 			nn := types.NamespacedName{Name: cr.Name, Namespace: testNamespace}
 			reconciler := &AxonOpsLogCollectorReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
 
-			// First reconcile: finalizer
+			// First reconcile: adds finalizer, no API calls
 			_, _ = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: nn})
-			// Second reconcile: sync
+			// Second reconcile: syncs (GET + PUT)
 			_, _ = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: nn})
 
-			callsAfterSync := apiCallCount.Load()
+			Expect(k8sClient.Get(ctx, nn, cr)).To(Succeed())
+			syncedUUID = cr.Status.SyncedUUID
+			Expect(syncedUUID).NotTo(BeEmpty())
 
-			// Third reconcile: should be idempotent
+			getCallsAfterSync := getCalls.Load()
+			putCallsAfterSync := putCalls.Load()
+
+			// Third reconcile: drift check only (1 GET, no PUT)
 			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: nn})
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(apiCallCount.Load()).To(Equal(callsAfterSync))
+			Expect(getCalls.Load()).To(Equal(getCallsAfterSync + 1))
+			Expect(putCalls.Load()).To(Equal(putCallsAfterSync))
 		})
 	})
 

--- a/internal/controller/alerts/axonopsmetricalert_controller.go
+++ b/internal/controller/alerts/axonopsmetricalert_controller.go
@@ -125,14 +125,14 @@ func (r *AxonOpsMetricAlertReconciler) Reconcile(ctx context.Context, req ctrl.R
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 	}
 
-	// Check if alert is already synced with observed generation matching
-	// This avoids unnecessary API calls on every reconciliation
+	// Check if alert is already synced with drift detection
 	readyCond := meta.FindStatusCondition(alert.Status.Conditions, condTypeReady)
 	if readyCond != nil && readyCond.Status == metav1.ConditionTrue &&
 		alert.Status.ObservedGeneration == alert.Generation &&
 		alert.Status.SyncedAlertID != "" {
-		log.Info("Alert already synced and spec unchanged, skipping API call")
-		return ctrl.Result{}, nil
+		if result, done, err := r.checkDrift(ctx, alert, apiClient); done {
+			return result, err
+		}
 	}
 
 	// Set Progressing condition
@@ -228,6 +228,46 @@ func (r *AxonOpsMetricAlertReconciler) Reconcile(ctx context.Context, req ctrl.R
 
 	log.Info("Successfully synced alert rule", "alertID", result.ID)
 	return ctrl.Result{}, nil
+}
+
+// checkDrift verifies whether the synced metric alert rule still exists in AxonOps.
+// Returns (result, true, err) if the reconcile loop should return; (zero, false, nil) to continue.
+func (r *AxonOpsMetricAlertReconciler) checkDrift(ctx context.Context, alert *alertsv1alpha1.AxonOpsMetricAlert, apiClient *axonops.Client) (ctrl.Result, bool, error) {
+	log := logf.FromContext(ctx)
+	rules, err := apiClient.GetMetricAlertRules(ctx, alert.Spec.ClusterType, alert.Spec.ClusterName)
+	if err != nil {
+		log.Error(err, "Failed to perform drift check")
+		meta.SetStatusCondition(&alert.Status.Conditions, metav1.Condition{
+			Type:               "DriftCheckFailed",
+			Status:             metav1.ConditionTrue,
+			ObservedGeneration: alert.Generation,
+			Reason:             "DriftCheckFailed",
+			Message:            common.SafeConditionMsg("Failed to check for drift", err),
+		})
+		if statusErr := r.Status().Update(ctx, alert); statusErr != nil {
+			log.Error(statusErr, "Failed to update status")
+		}
+		return ctrl.Result{RequeueAfter: common.DriftCheckInterval}, true, nil
+	}
+	for _, rule := range rules {
+		if rule.ID == alert.Status.SyncedAlertID {
+			log.Info("Alert already synced and spec unchanged, skipping API call")
+			return ctrl.Result{RequeueAfter: common.DriftCheckInterval}, true, nil
+		}
+	}
+	log.Info("Drift detected: alert rule no longer exists in AxonOps", "alertID", alert.Status.SyncedAlertID)
+	meta.SetStatusCondition(&alert.Status.Conditions, metav1.Condition{
+		Type:               "DriftDetected",
+		Status:             metav1.ConditionTrue,
+		ObservedGeneration: alert.Generation,
+		Reason:             "ResourceDeleted",
+		Message:            "Alert rule was deleted externally; recreating",
+	})
+	alert.Status.SyncedAlertID = ""
+	if statusErr := r.Status().Update(ctx, alert); statusErr != nil {
+		return ctrl.Result{}, true, statusErr
+	}
+	return ctrl.Result{}, false, nil
 }
 
 // handleDeletion handles cleanup when the CR is being deleted

--- a/internal/controller/alerts/axonopsscheduledrepair_controller.go
+++ b/internal/controller/alerts/axonopsscheduledrepair_controller.go
@@ -133,13 +133,14 @@ func (r *AxonOpsScheduledRepairReconciler) Reconcile(ctx context.Context, req ct
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 	}
 
-	// Check idempotency
+	// Check idempotency with drift detection
 	readyCond := meta.FindStatusCondition(repair.Status.Conditions, condTypeReady)
 	if readyCond != nil && readyCond.Status == metav1.ConditionTrue &&
 		repair.Status.ObservedGeneration == repair.Generation &&
 		repair.Status.SyncedRepairID != "" {
-		log.Info("Repair already synced and spec unchanged, skipping API call")
-		return ctrl.Result{}, nil
+		if result, done, err := r.checkDrift(ctx, repair, apiClient); done {
+			return result, err
+		}
 	}
 
 	// If updating, delete the old repair first
@@ -212,6 +213,46 @@ func (r *AxonOpsScheduledRepairReconciler) Reconcile(ctx context.Context, req ct
 
 	log.Info("Successfully synced scheduled repair", "repairID", syncedID, "tag", repair.Spec.Tag)
 	return ctrl.Result{}, nil
+}
+
+// checkDrift verifies whether the synced scheduled repair still exists in AxonOps.
+// Returns (result, true, err) if the reconcile loop should return; (zero, false, nil) to continue.
+func (r *AxonOpsScheduledRepairReconciler) checkDrift(ctx context.Context, repair *alertsv1alpha1.AxonOpsScheduledRepair, apiClient *axonops.Client) (ctrl.Result, bool, error) {
+	log := logf.FromContext(ctx)
+	repairs, err := apiClient.GetScheduledRepairs(ctx, repair.Spec.ClusterType, repair.Spec.ClusterName)
+	if err != nil {
+		log.Error(err, "Failed to perform drift check")
+		meta.SetStatusCondition(&repair.Status.Conditions, metav1.Condition{
+			Type:               "DriftCheckFailed",
+			Status:             metav1.ConditionTrue,
+			ObservedGeneration: repair.Generation,
+			Reason:             "DriftCheckFailed",
+			Message:            common.SafeConditionMsg("Failed to check for drift", err),
+		})
+		if statusErr := r.Status().Update(ctx, repair); statusErr != nil {
+			log.Error(statusErr, "Failed to update status")
+		}
+		return ctrl.Result{RequeueAfter: common.DriftCheckInterval}, true, nil
+	}
+	for _, entry := range repairs.Repairs {
+		if entry.ID == repair.Status.SyncedRepairID {
+			log.Info("Repair already synced and spec unchanged, skipping API call")
+			return ctrl.Result{RequeueAfter: common.DriftCheckInterval}, true, nil
+		}
+	}
+	log.Info("Drift detected: scheduled repair no longer exists in AxonOps", "repairID", repair.Status.SyncedRepairID)
+	meta.SetStatusCondition(&repair.Status.Conditions, metav1.Condition{
+		Type:               "DriftDetected",
+		Status:             metav1.ConditionTrue,
+		ObservedGeneration: repair.Generation,
+		Reason:             "ResourceDeleted",
+		Message:            "Scheduled repair was deleted externally; recreating",
+	})
+	repair.Status.SyncedRepairID = ""
+	if statusErr := r.Status().Update(ctx, repair); statusErr != nil {
+		return ctrl.Result{}, true, statusErr
+	}
+	return ctrl.Result{}, false, nil
 }
 
 func (r *AxonOpsScheduledRepairReconciler) handleDeletion(ctx context.Context, repair *alertsv1alpha1.AxonOpsScheduledRepair) (ctrl.Result, error) {

--- a/internal/controller/alerts/axonopssilencewindow_controller.go
+++ b/internal/controller/alerts/axonopssilencewindow_controller.go
@@ -117,13 +117,14 @@ func (r *AxonOpsSilenceWindowReconciler) Reconcile(ctx context.Context, req ctrl
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 	}
 
-	// Check idempotency
+	// Check idempotency with drift detection
 	readyCond := meta.FindStatusCondition(silence.Status.Conditions, condTypeReady)
 	if readyCond != nil && readyCond.Status == metav1.ConditionTrue &&
 		silence.Status.ObservedGeneration == silence.Generation &&
 		silence.Status.SyncedSilenceID != "" {
-		log.Info("Silence already synced and spec unchanged, skipping API call")
-		return ctrl.Result{}, nil
+		if result, done, err := r.checkDrift(ctx, silence, apiClient); done {
+			return result, err
+		}
 	}
 
 	active := true
@@ -207,6 +208,46 @@ func (r *AxonOpsSilenceWindowReconciler) Reconcile(ctx context.Context, req ctrl
 
 	log.Info("Successfully synced silence window", "silenceID", syncedID)
 	return ctrl.Result{}, nil
+}
+
+// checkDrift verifies whether the synced silence window still exists in AxonOps.
+// Returns (result, true, err) if the reconcile loop should return; (zero, false, nil) to continue.
+func (r *AxonOpsSilenceWindowReconciler) checkDrift(ctx context.Context, silence *alertsv1alpha1.AxonOpsSilenceWindow, apiClient *axonops.Client) (ctrl.Result, bool, error) {
+	log := logf.FromContext(ctx)
+	silences, err := apiClient.GetSilenceWindows(ctx, silence.Spec.ClusterType, silence.Spec.ClusterName)
+	if err != nil {
+		log.Error(err, "Failed to perform drift check")
+		meta.SetStatusCondition(&silence.Status.Conditions, metav1.Condition{
+			Type:               "DriftCheckFailed",
+			Status:             metav1.ConditionTrue,
+			ObservedGeneration: silence.Generation,
+			Reason:             "DriftCheckFailed",
+			Message:            common.SafeConditionMsg("Failed to check for drift", err),
+		})
+		if statusErr := r.Status().Update(ctx, silence); statusErr != nil {
+			log.Error(statusErr, "Failed to update status")
+		}
+		return ctrl.Result{RequeueAfter: common.DriftCheckInterval}, true, nil
+	}
+	for _, s := range silences {
+		if s.ID == silence.Status.SyncedSilenceID {
+			log.Info("Silence already synced and spec unchanged, skipping API call")
+			return ctrl.Result{RequeueAfter: common.DriftCheckInterval}, true, nil
+		}
+	}
+	log.Info("Drift detected: silence window no longer exists in AxonOps", "silenceID", silence.Status.SyncedSilenceID)
+	meta.SetStatusCondition(&silence.Status.Conditions, metav1.Condition{
+		Type:               "DriftDetected",
+		Status:             metav1.ConditionTrue,
+		ObservedGeneration: silence.Generation,
+		Reason:             "ResourceDeleted",
+		Message:            "Silence window was deleted externally; recreating",
+	})
+	silence.Status.SyncedSilenceID = ""
+	if statusErr := r.Status().Update(ctx, silence); statusErr != nil {
+		return ctrl.Result{}, true, statusErr
+	}
+	return ctrl.Result{}, false, nil
 }
 
 func (r *AxonOpsSilenceWindowReconciler) handleDeletion(ctx context.Context, silence *alertsv1alpha1.AxonOpsSilenceWindow) (ctrl.Result, error) {

--- a/internal/controller/backups/axonopsbackup_controller.go
+++ b/internal/controller/backups/axonopsbackup_controller.go
@@ -143,13 +143,14 @@ func (r *AxonOpsBackupReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 	}
 
-	// Check idempotency
+	// Check idempotency with drift detection
 	readyCond := meta.FindStatusCondition(backup.Status.Conditions, condTypeReady)
 	if readyCond != nil && readyCond.Status == metav1.ConditionTrue &&
 		backup.Status.ObservedGeneration == backup.Generation &&
 		backup.Status.SyncedBackupID != "" {
-		log.Info("Backup already synced and spec unchanged, skipping API call")
-		return ctrl.Result{}, nil
+		if result, done, driftErr := r.checkDrift(ctx, backup, apiClient); done {
+			return result, driftErr
+		}
 	}
 
 	// Build the backup payload
@@ -232,6 +233,46 @@ func (r *AxonOpsBackupReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	log.Info("Successfully synced backup schedule", "backupID", syncedID, "tag", backup.Spec.Tag)
 	return ctrl.Result{}, nil
+}
+
+// checkDrift verifies whether the scheduled backup still exists in AxonOps.
+// Returns (result, true, err) if the reconcile loop should return; (zero, false, nil) to continue.
+func (r *AxonOpsBackupReconciler) checkDrift(ctx context.Context, backup *backupsv1alpha1.AxonOpsBackup, apiClient *axonops.Client) (ctrl.Result, bool, error) {
+	log := logf.FromContext(ctx)
+	snapshots, err := apiClient.GetScheduledSnapshots(ctx, backup.Spec.ClusterType, backup.Spec.ClusterName)
+	if err != nil {
+		log.Error(err, "Failed to perform drift check")
+		meta.SetStatusCondition(&backup.Status.Conditions, metav1.Condition{
+			Type:               "DriftCheckFailed",
+			Status:             metav1.ConditionTrue,
+			ObservedGeneration: backup.Generation,
+			Reason:             "DriftCheckFailed",
+			Message:            common.SafeConditionMsg("Failed to check for drift", err),
+		})
+		if statusErr := r.Status().Update(ctx, backup); statusErr != nil {
+			log.Error(statusErr, "Failed to update status")
+		}
+		return ctrl.Result{RequeueAfter: common.DriftCheckInterval}, true, nil
+	}
+	for _, s := range snapshots.ScheduledSnapshots {
+		if s.ID == backup.Status.SyncedBackupID {
+			log.Info("Backup already synced and spec unchanged, skipping API call")
+			return ctrl.Result{RequeueAfter: common.DriftCheckInterval}, true, nil
+		}
+	}
+	log.Info("Drift detected: scheduled backup no longer exists in AxonOps", "backupID", backup.Status.SyncedBackupID)
+	meta.SetStatusCondition(&backup.Status.Conditions, metav1.Condition{
+		Type:               "DriftDetected",
+		Status:             metav1.ConditionTrue,
+		ObservedGeneration: backup.Generation,
+		Reason:             "ResourceDeleted",
+		Message:            "Scheduled backup was deleted externally; recreating",
+	})
+	backup.Status.SyncedBackupID = ""
+	if statusErr := r.Status().Update(ctx, backup); statusErr != nil {
+		return ctrl.Result{}, true, statusErr
+	}
+	return ctrl.Result{}, false, nil
 }
 
 // handleDeletion handles cleanup when the CR is being deleted

--- a/internal/controller/common/connection.go
+++ b/internal/controller/common/connection.go
@@ -34,6 +34,9 @@ import (
 	"github.com/axonops/axonops-operator/internal/axonops"
 )
 
+// DriftCheckInterval is the period between drift checks on already-synced resources.
+const DriftCheckInterval = 5 * time.Minute
+
 // Shared condition reasons used across controller groups
 const (
 	ReasonConnectionError  = "ConnectionError"


### PR DESCRIPTION
## Summary

- Adds `DriftCheckInterval = 5 * time.Minute` constant to the `common` package
- Adds a `checkDrift` helper method to each of the 14 CRD controllers
- When a resource is already synced (Ready=True, ObservedGeneration matches, synced ID non-empty), the controller calls `checkDrift` to verify the resource still exists externally in AxonOps before short-circuiting
- If drift is detected (resource was deleted externally), sets `DriftDetected` condition, clears the synced ID, and falls through to recreate
- If the drift-check API call fails, sets `DriftCheckFailed` condition and requeues after the drift interval

## Design notes

- Controllers that resolve `apiClient` before the idempotency guard (most): `checkDrift` takes `apiClient` as a param
- Controllers that resolve `apiClient` after the idempotency guard (AlertEndpoint, AlertRoute): `checkDrift` resolves its own client internally
- Singleton resources without IDs (AdaptiveRepair, DashboardTemplate, CommitlogArchive): drift detected by settings comparison or empty-list check
- Kafka controllers (Topic, ACL, Connector): no drift detection — no List/Get API methods available
- Extracted `applyRoute` helper in AlertRoute to keep `Reconcile` cyclomatic complexity ≤ 30

## Test plan

- [ ] `make lint` passes with 0 issues
- [ ] `make test` passes across all packages
- [ ] LogCollector idempotency test updated: mock server is stateful, asserts 1 drift-check GET and 0 extra PUTs
- [ ] Manually verify drift detection by creating a resource, deleting it in AxonOps UI, and confirming the operator recreates it within 5 minutes

Closes #94